### PR TITLE
Feat(test): giving some love to tests

### DIFF
--- a/spec/auth-guard.test.ts
+++ b/spec/auth-guard.test.ts
@@ -65,12 +65,12 @@ class MethodGuardModule {}
 })
 class ControllerGuardModule {}
 
-for (let guardType of ['controller', 'method']) {
+for (const guardType of ['controller', 'method']) {
 	Deno.test(`${guardType} guard`, async () => {
 		const app = new DanetApplication();
 		await app.init(ControllerGuardModule);
-		const port = (await app.listen(0)).port;
-		const res = await fetch(`http://localhost:${port}/${guardType}-guard`, {
+		const listenEvent = await app.listen();
+		const res = await fetch(`http://localhost:${listenEvent.port}/${guardType}-guard`, {
 			method: 'GET',
 		});
 		const json = await res.json();
@@ -97,8 +97,8 @@ class GlobalAuthModule {}
 Deno.test('Global guard', async () => {
 	const app = new DanetApplication();
 	await app.init(GlobalAuthModule);
-	const port = (await app.listen(0)).port;
-	const res = await fetch(`http://localhost:${port}/global-guard`, {
+	const listenEvent = await app.listen();
+	const res = await fetch(`http://localhost:${listenEvent.port}/global-guard`, {
 		method: 'GET',
 	});
 	const json = await res.json();
@@ -110,7 +110,7 @@ Deno.test('Global guard', async () => {
 
 @Injectable()
 class ThrowingGuard implements AuthGuard {
-	canActivate(context: HttpContext) {
+	canActivate() {
 		return false;
 	}
 }
@@ -131,8 +131,8 @@ class ThrowingAuthModule {}
 Deno.test('403 when guard is throwing', async () => {
 	const app = new DanetApplication();
 	await app.init(ThrowingAuthModule);
-	const port = (await app.listen(0)).port;
-	const res = await fetch(`http://localhost:${port}/throwing-guard`, {
+	const listenEvent = await app.listen();
+	const res = await fetch(`http://localhost:${listenEvent.port}/throwing-guard`, {
 		method: 'GET',
 	});
 	const errorStatus = res.status;

--- a/spec/auth-guard.test.ts
+++ b/spec/auth-guard.test.ts
@@ -69,7 +69,7 @@ for (const guardType of ['controller', 'method']) {
 	Deno.test(`${guardType} guard`, async () => {
 		const app = new DanetApplication();
 		await app.init(ControllerGuardModule);
-		const listenEvent = await app.listen();
+		const listenEvent = await app.listen(0);
 		const res = await fetch(`http://localhost:${listenEvent.port}/${guardType}-guard`, {
 			method: 'GET',
 		});
@@ -97,7 +97,7 @@ class GlobalAuthModule {}
 Deno.test('Global guard', async () => {
 	const app = new DanetApplication();
 	await app.init(GlobalAuthModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 	const res = await fetch(`http://localhost:${listenEvent.port}/global-guard`, {
 		method: 'GET',
 	});
@@ -131,7 +131,7 @@ class ThrowingAuthModule {}
 Deno.test('403 when guard is throwing', async () => {
 	const app = new DanetApplication();
 	await app.init(ThrowingAuthModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 	const res = await fetch(`http://localhost:${listenEvent.port}/throwing-guard`, {
 		method: 'GET',
 	});

--- a/spec/exception-filter.test.ts
+++ b/spec/exception-filter.test.ts
@@ -66,7 +66,7 @@ for (
 	Deno.test(testName, async () => {
 		const app = new DanetApplication();
 		await app.init(ModuleWithFilter);
-		const listenEvent = await app.listen();
+		const listenEvent = await app.listen(0);
 
 		const res = await fetch(`http://localhost:${listenEvent.port}/custom-error`, {
 			method: 'GET',
@@ -82,7 +82,7 @@ for (
 Deno.test('Controller filter works', async () => {
 	const app = new DanetApplication();
 	await app.init(ModuleWithFilter);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}`, {
 		method: 'GET',
@@ -97,7 +97,7 @@ Deno.test('Controller filter works', async () => {
 Deno.test('throw 500 on unexpected error', async () => {
 	const app = new DanetApplication();
 	await app.init(ModuleWithFilter);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(
 		`http://localhost:${listenEvent.port}/custom-error/unexpected-error`,

--- a/spec/exception-filter.test.ts
+++ b/spec/exception-filter.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from 'https://deno.land/std@0.135.0/testing/asserts.ts';
+import { assertEquals } from '../src/deps_test.ts';
 import { DanetApplication } from '../src/app.ts';
 import { Catch, UseFilter } from '../src/exception/filter/decorator.ts';
 import { ExceptionFilter } from '../src/exception/filter/interface.ts';
@@ -66,9 +66,9 @@ for (
 	Deno.test(testName, async () => {
 		const app = new DanetApplication();
 		await app.init(ModuleWithFilter);
-		const port = (await app.listen(0)).port;
+		const listenEvent = await app.listen();
 
-		const res = await fetch(`http://localhost:${port}/custom-error`, {
+		const res = await fetch(`http://localhost:${listenEvent.port}/custom-error`, {
 			method: 'GET',
 		});
 		const json = await res.json();
@@ -82,9 +82,9 @@ for (
 Deno.test('Controller filter works', async () => {
 	const app = new DanetApplication();
 	await app.init(ModuleWithFilter);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}`, {
 		method: 'GET',
 	});
 	const json = await res.json();
@@ -97,10 +97,10 @@ Deno.test('Controller filter works', async () => {
 Deno.test('throw 500 on unexpected error', async () => {
 	const app = new DanetApplication();
 	await app.init(ModuleWithFilter);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
 	const res = await fetch(
-		`http://localhost:${port}/custom-error/unexpected-error`,
+		`http://localhost:${listenEvent.port}/custom-error/unexpected-error`,
 		{
 			method: 'GET',
 		},

--- a/spec/http-methods.test.ts
+++ b/spec/http-methods.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from 'https://deno.land/std@0.135.0/testing/asserts.ts';
+import { assertEquals } from '../src/deps_test.ts';
 import { DanetApplication } from '../src/app.ts';
 import { Module } from '../src/module/decorator.ts';
 import {
@@ -50,13 +50,13 @@ class SimpleController {
 class MyModule {}
 
 const app = new DanetApplication();
-for (let method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']) {
+for (const method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']) {
 	Deno.test(method, async () => {
 		await app.init(MyModule);
-		const port = (await app.listen(0)).port;
+		const listenEvent = await app.listen();
 
-		const res = await fetch(`http://localhost:${port}/nice-controller`, {
-			method: method,
+		const res = await fetch(`http://localhost:${listenEvent.port}/nice-controller`, {
+			method,
 		});
 		const text = await res.text();
 		assertEquals(text, `OK ${method}`);
@@ -66,12 +66,15 @@ for (let method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']) {
 
 Deno.test('ALL', async () => {
 	await app.init(MyModule);
-	app.listen(3000);
+	const listenEvent = await app.listen();
 
-	for (let method of ['GET', 'POST', 'PUT', 'DELETE']) {
-		const res = await fetch('http://localhost:3000/nice-controller/all', {
-			method: method,
-		});
+	for (const method of ['GET', 'POST', 'PUT', 'DELETE']) {
+		const res = await fetch(
+			`http://localhost:${listenEvent.port}/nice-controller/all`,
+			{
+				method: method,
+			},
+		);
 		const text = await res.text();
 		assertEquals(text, `OK ALL`);
 	}

--- a/spec/http-methods.test.ts
+++ b/spec/http-methods.test.ts
@@ -53,7 +53,7 @@ const app = new DanetApplication();
 for (const method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']) {
 	Deno.test(method, async () => {
 		await app.init(MyModule);
-		const listenEvent = await app.listen();
+		const listenEvent = await app.listen(0);
 
 		const res = await fetch(`http://localhost:${listenEvent.port}/nice-controller`, {
 			method,
@@ -66,7 +66,7 @@ for (const method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']) {
 
 Deno.test('ALL', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	for (const method of ['GET', 'POST', 'PUT', 'DELETE']) {
 		const res = await fetch(

--- a/spec/injection.test.ts
+++ b/spec/injection.test.ts
@@ -3,8 +3,8 @@ import {
 	assertInstanceOf,
 	assertNotEquals,
 	assertRejects,
-} from 'https://deno.land/std@0.135.0/testing/asserts.ts';
-import { Route } from 'https://deno.land/x/oak@v10.5.1/router.ts';
+} from '../src/deps_test.ts';
+import { Route } from '../src/deps.ts';
 import { DanetApplication } from '../src/app.ts';
 import { GLOBAL_GUARD } from '../src/guard/constants.ts';
 import { AuthGuard } from '../src/guard/interface.ts';

--- a/spec/lifecycle-hook.test.ts
+++ b/spec/lifecycle-hook.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from 'https://deno.land/std@0.135.0/testing/asserts.ts';
+import { assertEquals } from '../src/deps_test.ts';
 import { DanetApplication } from '../src/app.ts';
 import { OnAppBootstrap, OnAppClose } from '../src/hook/interfaces.ts';
 import { Injectable, SCOPE } from '../src/injector/injectable/decorator.ts';
@@ -46,15 +46,21 @@ Deno.test('Lifecycle hooks', async (testContext) => {
 	const app = new DanetApplication();
 	await app.init(MyModule);
 
-	await testContext.step('call global injectables onAppBootstrap hook', async () => {
-		const injectableWithHook = await app.get(InjectableWithHook);
-		assertEquals(injectableWithHook.appBoostrapCalled, true);
-	});
+	await testContext.step(
+		'call global injectables onAppBootstrap hook',
+		async () => {
+			const injectableWithHook = await app.get(InjectableWithHook);
+			assertEquals(injectableWithHook.appBoostrapCalled, true);
+		},
+	);
 
-	await testContext.step('call global controller onAppBootstrap hook', async () => {
-		const controllerWithHook = await app.get(ControllerWithHook);
-		assertEquals(controllerWithHook.appBoostrapCalled, true);
-	});
+	await testContext.step(
+		'call global controller onAppBootstrap hook',
+		async () => {
+			const controllerWithHook = await app.get(ControllerWithHook);
+			assertEquals(controllerWithHook.appBoostrapCalled, true);
+		},
+	);
 
 	await testContext.step(
 		'call injectables and controllers onAppClosehook when app is closed',

--- a/spec/method-param-decorator.test.ts
+++ b/spec/method-param-decorator.test.ts
@@ -55,7 +55,7 @@ const app = new DanetApplication();
 
 Deno.test('@Res and @Query decorator', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}?myvalue=foo`, {
 		method: 'GET',
@@ -67,7 +67,7 @@ Deno.test('@Res and @Query decorator', async () => {
 
 Deno.test('@Header decorator with attribute', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/lambda`, {
 		method: 'GET',
@@ -82,7 +82,7 @@ Deno.test('@Header decorator with attribute', async () => {
 
 Deno.test('@Header decorator without attribute', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/lambda`, {
 		method: 'POST',
@@ -97,7 +97,7 @@ Deno.test('@Header decorator without attribute', async () => {
 
 Deno.test('@Header decorator with attribute without qualifying header on request', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/lambda`, {
 		method: 'GET',
@@ -110,7 +110,7 @@ Deno.test('@Header decorator with attribute without qualifying header on request
 
 Deno.test('@Body decorator with attribute', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}`, {
 		method: 'POST',
@@ -126,7 +126,7 @@ Deno.test('@Body decorator with attribute', async () => {
 
 Deno.test('@Body decorator', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/full-body/`, {
 		method: 'POST',
@@ -144,7 +144,7 @@ Deno.test('@Body decorator', async () => {
 
 Deno.test('@Param decorator', async () => {
 	await app.init(MyModule);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/batman`, {
 		method: 'GET',

--- a/spec/method-param-decorator.test.ts
+++ b/spec/method-param-decorator.test.ts
@@ -55,9 +55,9 @@ const app = new DanetApplication();
 
 Deno.test('@Res and @Query decorator', async () => {
 	await app.init(MyModule);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}?myvalue=foo`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}?myvalue=foo`, {
 		method: 'GET',
 	});
 	const text = await res.text();
@@ -67,9 +67,9 @@ Deno.test('@Res and @Query decorator', async () => {
 
 Deno.test('@Header decorator with attribute', async () => {
 	await app.init(MyModule);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/lambda`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/lambda`, {
 		method: 'GET',
 		headers: {
 			'New-Header': 'en-US',
@@ -82,9 +82,9 @@ Deno.test('@Header decorator with attribute', async () => {
 
 Deno.test('@Header decorator without attribute', async () => {
 	await app.init(MyModule);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/lambda`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/lambda`, {
 		method: 'POST',
 		headers: {
 			'content-type': 'application/json',
@@ -97,9 +97,9 @@ Deno.test('@Header decorator without attribute', async () => {
 
 Deno.test('@Header decorator with attribute without qualifying header on request', async () => {
 	await app.init(MyModule);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/lambda`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/lambda`, {
 		method: 'GET',
 		headers: {},
 	});
@@ -110,9 +110,9 @@ Deno.test('@Header decorator with attribute without qualifying header on request
 
 Deno.test('@Body decorator with attribute', async () => {
 	await app.init(MyModule);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}`, {
 		method: 'POST',
 		headers: {
 			'content-type': 'application/json',
@@ -126,9 +126,9 @@ Deno.test('@Body decorator with attribute', async () => {
 
 Deno.test('@Body decorator', async () => {
 	await app.init(MyModule);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/full-body/`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/full-body/`, {
 		method: 'POST',
 		headers: {
 			'content-type': 'application/json',
@@ -144,9 +144,9 @@ Deno.test('@Body decorator', async () => {
 
 Deno.test('@Param decorator', async () => {
 	await app.init(MyModule);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/batman`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/batman`, {
 		method: 'GET',
 		headers: {
 			'content-type': 'application/json',

--- a/spec/render-static-files.test.ts
+++ b/spec/render-static-files.test.ts
@@ -22,9 +22,9 @@ Deno.test('it serve static files', async () => {
 	const staticAssetsPath = path.dirname(path.fromFileUrl(import.meta.url)) +
 		'/static';
 	app.useStaticAssets(staticAssetsPath);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/test.txt`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/test.txt`, {
 		method: 'GET',
 	});
 	const blob = await res.blob();
@@ -39,9 +39,9 @@ Deno.test('serving static file does not break routes', async () => {
 	const staticAssetsPath = path.dirname(path.fromFileUrl(import.meta.url)) +
 		'/static';
 	app.useStaticAssets(staticAssetsPath);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/todo`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/todo`, {
 		method: 'GET',
 	});
 	const text = await res.text();

--- a/spec/render-static-files.test.ts
+++ b/spec/render-static-files.test.ts
@@ -22,7 +22,7 @@ Deno.test('it serve static files', async () => {
 	const staticAssetsPath = path.dirname(path.fromFileUrl(import.meta.url)) +
 		'/static';
 	app.useStaticAssets(staticAssetsPath);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/test.txt`, {
 		method: 'GET',
@@ -39,7 +39,7 @@ Deno.test('serving static file does not break routes', async () => {
 	const staticAssetsPath = path.dirname(path.fromFileUrl(import.meta.url)) +
 		'/static';
 	app.useStaticAssets(staticAssetsPath);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/todo`, {
 		method: 'GET',

--- a/spec/scoped-lifecycle-hook.test.ts
+++ b/spec/scoped-lifecycle-hook.test.ts
@@ -40,7 +40,7 @@ Deno.test('Scoped Lifecycle hooks', async (testContext) => {
 	await testContext.step(
 		'handleRequest is called before request when defined in a scoped service',
 		async () => {
-			const listenEvent = await app.listen();
+			const listenEvent = await app.listen(0);
 
 			const res = await fetch(`http://localhost:${listenEvent.port}/scoped-controller/`, {
 				method: 'GET',

--- a/spec/view-renderer.test.ts
+++ b/spec/view-renderer.test.ts
@@ -23,7 +23,7 @@ Deno.test('Hbs renderer', async () => {
 	await app.init(MyModule);
 	const viewPath = path.dirname(path.fromFileUrl(import.meta.url)) + '/views';
 	app.setViewEngineDir(viewPath);
-	const listenEvent = await app.listen();
+	const listenEvent = await app.listen(0);
 
 	const res = await fetch(`http://localhost:${listenEvent.port}/nice-controller`, {
 		method: 'GET',

--- a/spec/view-renderer.test.ts
+++ b/spec/view-renderer.test.ts
@@ -1,5 +1,4 @@
-import { assertEquals } from 'https://deno.land/std@0.135.0/testing/asserts.ts';
-import * as path from 'https://deno.land/std@0.135.0/path/mod.ts';
+import { path, assertEquals } from '../src/deps_test.ts';
 import { DanetApplication } from '../src/app.ts';
 import { Module } from '../src/module/decorator.ts';
 import { Render } from '../src/renderer/decorator.ts';
@@ -24,9 +23,9 @@ Deno.test('Hbs renderer', async () => {
 	await app.init(MyModule);
 	const viewPath = path.dirname(path.fromFileUrl(import.meta.url)) + '/views';
 	app.setViewEngineDir(viewPath);
-	const port = (await app.listen(0)).port;
+	const listenEvent = await app.listen();
 
-	const res = await fetch(`http://localhost:${port}/nice-controller`, {
+	const res = await fetch(`http://localhost:${listenEvent.port}/nice-controller`, {
 		method: 'GET',
 	});
 	const text = await res.text();

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,7 @@ export class DanetApplication {
 		this.controller.abort();
 	}
 
-	listen(port = 3000): Promise<ApplicationListenEvent> {
+	listen(port = 0): Promise<ApplicationListenEvent> {
 		const routes = this.router.routes();
 		this.app.use(routes);
 		this.controller = new AbortController();

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,7 @@ export class DanetApplication {
 		this.controller.abort();
 	}
 
-	listen(port = 0): Promise<ApplicationListenEvent> {
+	listen(port = 3000): Promise<ApplicationListenEvent> {
 		const routes = this.router.routes();
 		this.app.use(routes);
 		this.controller = new AbortController();

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -5,7 +5,7 @@ export {
 	Response,
 	Router,
 } from 'https://deno.land/x/oak@v10.5.1/mod.ts';
-export type { State } from 'https://deno.land/x/oak@v10.5.1/mod.ts';
+export type { State, Route } from 'https://deno.land/x/oak@v10.5.1/mod.ts';
 export { getQuery } from 'https://deno.land/x/oak@v10.5.1/helpers.ts';
 export {
 	green,

--- a/src/deps_test.ts
+++ b/src/deps_test.ts
@@ -1,2 +1,7 @@
-export { assertEquals } from 'https://deno.land/std@0.135.0/testing/asserts.ts';
+export {
+	assertEquals,
+	assertInstanceOf,
+	assertNotEquals,
+	assertRejects,
+} from 'https://deno.land/std@0.135.0/testing/asserts.ts';
 export * as path from 'https://deno.land/std@0.135.0/path/mod.ts';


### PR DESCRIPTION
## Description
It's quite common to look at tests when docs are not enough, especially for specific use case.
In its current state, the code is not showing using the framework in the most elegant way and we still have a few URL dependencies.
This PR aim to improve all those points by giving some love to the tests <3

It also introduce a single **breaking change** which is to change the default value for the `port` parameter of `DanetApplication.listen()` from `3000` to `0`. Most respectable frameworks (Express, NestJS, Oak, etc.) will use 0 if no port is provided, why not Danet!

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have run `deno lint` AND `deno fmt` AND `deno task test` and got no errors.
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Savory/Danet/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes needed to the documentation
