### PR TITLE
Feat: Allow query params to return all values

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -23,6 +23,7 @@
 		"emitDecoratorMetadata": true
 	},
 	"tasks": {
-		"test": "NO_LOG=true deno test --allow-env --allow-net --allow-read -A --unstable --coverage=coverage spec"
+		"test": "NO_LOG=true deno test --allow-env --allow-net --allow-read -A --unstable --coverage=coverage spec",
+		"start:example": "deno run --allow-net --allow-env --watch example/run.ts"
 	}
 }

--- a/doc/overview/controllers.md
+++ b/doc/overview/controllers.md
@@ -85,49 +85,15 @@ not necessary to grab these properties manually. We can use dedicated decorators
 instead, such as `@Body()` or `@Query()`, which are available out of the box.
 Below is a list of the provided decorators and the plain platform-specific
 objects they represent.
-
-<table>
-  <tbody>
-    <tr>
-      <th>Decorator</th>
-      <th>Type</th>
-      <th>Value</th>
-    </tr>
-    <tr>
-      <td><code>@Req()</code></td>
-      <td><a href="https://deno.land/x/oak@v10.5.1/request.ts">oak.Request</a></td>
-      <td><code>ctx.request</code></td></tr>
-    <tr>
-      <td><code>@Res()</code></td>
-      <td><a href="https://deno.land/x/oak@v10.5.1/response.ts">oak.Response</a></td>
-      <td><code>ctx.response</code></td>
-    </tr>
-    <tr>
-      <td><code>@Param(key: string)</code></td>
-      <td><code>string</code></td>
-      <td><code>context.params[key]</code></td>
-    </tr>
-    <tr>
-      <td><code>@Header(key? : string)</code></td>
-      <td><code>string | undefined</code></td>
-      <td><code>ctx.request.headers</code> / <code>ctx.request.headers.get(key)</code></td></tr>
-    <tr>
-      <td><code>@Body(key?: string)</code></td>
-      <td><code>any</code></td>
-      <td><code>ctx.request.body</code> / <code>ctx.request.body[key]</code></td>
-    </tr>
-    <tr>
-      <td><code>@Query(key?: string)</code></td>
-      <td><code>string | { [key: string]: string }</code></td>
-      <td><code>getQuery(ctx)</code> / <code>getQuery(ctx)[key]</code></td>
-    </tr>
-    <tr>
-      <td><code>@QueryAll(key: string)</code></td>
-      <td><code>string[] | { [key: string]: string[] }</code></td>
-      <td>All query parameters grouped by key / <code>context.request.url.searchParams.getAll(params)</code></td>
-    </tr>
-  </tbody>
-</table>
+| Decorator | Type | Value |
+|-----------|------|-------|
+| `@Req()` | [oak.Request](https://deno.land/x/oak@v10.5.1/request.ts) | `ctx.request` |
+| `@Res()` | [oak.Response](https://deno.land/x/oak@v10.5.1/response.ts) | `ctx.response` |
+| `@Param(key: string)` | `string` | `context.params[key]` |
+| `@Header(key? : string)` | `string \| undefined` | `ctx.request.headers` / `ctx.request.headers.get(key)` |
+| `@Body(key?: string)` | `any` | `ctx.request.body` / `ctx.request.body[key]` |
+| `@Query(key: string, options?: { value?: 'first' \| 'last' \| 'array' })` | `string \| string[]` | Get the `first`, the `last` or `all` the values for the query parameter named `key` |
+| `@Query(options?: { value?: 'first' \| 'last' \| 'array' })` | `{ [key: string]: string \| string[] }` | Get the `first`, the `last` or `all` the values for all the query parameters |
 
 ### Resources
 

--- a/doc/overview/controllers.md
+++ b/doc/overview/controllers.md
@@ -89,26 +89,42 @@ objects they represent.
 <table>
   <tbody>
     <tr>
+      <th>Decorator</th>
+      <th>Type</th>
+      <th>Value</th>
+    </tr>
+    <tr>
       <td><code>@Req()</code></td>
+      <td><a href="https://deno.land/x/oak@v10.5.1/request.ts">oak.Request</a></td>
       <td><code>ctx.request</code></td></tr>
     <tr>
-      <td><code>@Res()</code><span class='table-code-asterisk'>*</span></td>
+      <td><code>@Res()</code></td>
+      <td><a href="https://deno.land/x/oak@v10.5.1/response.ts">oak.Response</a></td>
       <td><code>ctx.response</code></td>
     </tr>
     <tr>
       <td><code>@Param(key: string)</code></td>
-      <td><code>getQuery(context, { mergeParams: true })[key]</code></td>
+      <td><code>string</code></td>
+      <td><code>context.params[key]</code></td>
     </tr>
     <tr>
-    <td><code>@Header(key? : string)</code></td>
-    <td><code>ctx.request.headers</code> / <code>ctx.request.headers.get(key)</code></td></tr>
+      <td><code>@Header(key? : string)</code></td>
+      <td><code>string | undefined</code></td>
+      <td><code>ctx.request.headers</code> / <code>ctx.request.headers.get(key)</code></td></tr>
     <tr>
       <td><code>@Body(key?: string)</code></td>
+      <td><code>any</code></td>
       <td><code>ctx.request.body</code> / <code>ctx.request.body[key]</code></td>
     </tr>
     <tr>
-      <td><code>@Query(key: string)</code></td>
-      <td><code>getQuery(context, { mergeParams: true })[key]</code></td>
+      <td><code>@Query(key?: string)</code></td>
+      <td><code>string | { [key: string]: string }</code></td>
+      <td><code>getQuery(ctx)</code> / <code>getQuery(ctx)[key]</code></td>
+    </tr>
+    <tr>
+      <td><code>@QueryAll(key: string)</code></td>
+      <td><code>string[] | { [key: string]: string[] }</code></td>
+      <td>All query parameters grouped by key / <code>context.request.url.searchParams.getAll(params)</code></td>
     </tr>
   </tbody>
 </table>

--- a/example/run.ts
+++ b/example/run.ts
@@ -1,38 +1,77 @@
-import { DanetApplication } from '../src/mod.ts';
-import { Injectable, SCOPE } from '../src/injector/injectable/mod.ts';
-import { Module } from '../src/module/mod.ts';
 import {
 	All,
 	Body,
 	Controller,
+	DanetApplication,
 	Get,
+	Injectable,
+	Module,
+	Param,
 	Post,
+	Query,
 	Req,
-} from '../src/router/controller/mod.ts';
+	SCOPE,
+} from '../src/mod.ts';
 
-@Injectable({ scope: SCOPE.REQUEST })
-class Child2 {
-}
-
-@Injectable({ scope: SCOPE.REQUEST })
-class Child1 {
-	constructor(public child: Child2) {
-	}
-	getHelloWorld() {
-		return 'Hello World';
+@Injectable()
+class SharedService {
+	sum(nums: number[]): number {
+		return nums.reduce((sum, n) => sum + n, 0);
 	}
 }
 
-@Controller('/my-controller-path')
+@Injectable({ scope: SCOPE.REQUEST })
+class ScopedService2 {
+	getWorldHello() {
+		return 'World Hello';
+	}
+}
+
+@Injectable({ scope: SCOPE.REQUEST })
+class ScopedService1 {
+	constructor(public child: ScopedService2) {
+	}
+	getHelloWorld(name: string) {
+		return `Hello World ${name}`;
+	}
+}
+
+@Controller('')
 class FirstController {
-	constructor() {
+	constructor(
+		private sharedService: SharedService,
+		private scopedService1: ScopedService1,
+		private scopedService2: ScopedService2,
+	) {
 	}
+
 	@Get('')
 	getMethod() {
 		return 'OK';
 	}
 
+	@Get('hello-world/:name')
+	getHelloWorld(
+		@Param('name') name: string,
+	) {
+		return this.scopedService1.getHelloWorld(name);
+	}
+
+	@Get('world-hello')
+	getWorldHello() {
+		return this.scopedService2.getWorldHello();
+	}
+
+	@Get('sum')
+	getSum(
+		@Query('num') numParams: string | string[],
+	) {
+		const numString = Array.isArray(numParams) ? numParams : [numParams];
+		return this.sharedService.sum(numString.map((n) => Number(n)));
+	}
+
 	@Post('post')
+	// deno-lint-ignore no-explicit-any
 	postMethod(@Body() body: any) {
 		return body;
 	}
@@ -45,11 +84,15 @@ class FirstController {
 
 @Module({
 	controllers: [FirstController],
+	injectables: [SharedService, ScopedService1, ScopedService2],
 })
 class FirstModule {}
 
 const app = new DanetApplication();
 await app.init(FirstModule);
-const serve = app.listen(3000);
-console.log('listening on port 3000');
-await serve;
+
+let port = Number(Deno.env.get('PORT'));
+if (isNaN(port)) {
+	port = 3000;
+}
+app.listen(port);

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -6,7 +6,6 @@ export {
 	Router,
 } from 'https://deno.land/x/oak@v10.5.1/mod.ts';
 export type { State } from 'https://deno.land/x/oak@v10.5.1/mod.ts';
-export { getQuery } from 'https://deno.land/x/oak@v10.5.1/helpers.ts';
 export {
 	green,
 	red,

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -13,4 +13,4 @@ export {
 	white,
 	yellow,
 } from 'https://deno.land/std@0.135.0/fmt/colors.ts';
-export { Reflect } from "https://deno.land/x/deno_reflect@v0.2.1/mod.ts";
+export { Reflect } from 'https://deno.land/x/deno_reflect@v0.2.1/mod.ts';

--- a/src/router/controller/params/decorators.ts
+++ b/src/router/controller/params/decorators.ts
@@ -95,8 +95,8 @@ export function Query(pParamOrOptions?: string | QueryOption, pOptions?: QueryOp
 					])
 			);
 		}
-	}))()
-};
+	}))();
+}
 
 export const Param = (paramName: string) =>
 	createParamDecorator((context: HttpContext) => {


### PR DESCRIPTION
## Description
It is currently impossible to read all the values passed for a query param when it is present more than once, only the last one is kept.

For instance when for the following query `...?param=1&param=2`:  
`@Query('param')` would return `"2"`  
`@Query()` would return `{ "param": "2" }`  

This PR introduce a `@QueryAll` decorator that is similar `@Query` except it always return all the values instead of only the last one in the URL. Using the same example as earlier:  
`@QueryAll('param')` would return `["1", "2"]`  
`@QueryAll()` would return `{ "param": ["1", "2"] }`

I also slightly changed the way `@Param()` get the path parameters (it's untyped but I swear that's how you're supposed to do it) in order to not return query params as well (which could create some conflict issues).
While technically a breaking change, using `@Param()` to return the query params is most likely a terrible idea that I have never seen in any other frameworks.

---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---
# Checklist:
- [x] I have run `deno lint` AND `deno fmt` AND `deno task test` and got no errors.
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Savory/Danet/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes needed to the documentation
