### PR TITLE
make Danet Exceptions compatible with NestJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out
 gen
 node_modules
 coverage
+deno.lock

--- a/spec/auth-guard.test.ts
+++ b/spec/auth-guard.test.ts
@@ -7,7 +7,7 @@ import { TokenInjector } from '../src/injector/injectable/constructor.ts';
 import { Injectable } from '../src/injector/injectable/decorator.ts';
 import { Module } from '../src/module/decorator.ts';
 import { Controller, Get } from '../src/router/controller/decorator.ts';
-import { ExecutionContext, HttpContext } from '../src/router/router.ts';
+import { ExecutionContext } from '../src/router/router.ts';
 import { SetMetadata } from '../src/metadata/decorator.ts';
 import { MetadataHelper } from '../src/metadata/helper.ts';
 
@@ -181,8 +181,13 @@ Deno.test('403 when guard is throwing', async () => {
 	assertEquals(errorStatus, 403);
 	const json = await res.json();
 	assertEquals(json, {
-		message: '403 - Forbidden',
+		message: 'Forbidden',
 		name: 'ForbiddenException',
+		options: {},
+		response: {
+			message: 'Forbidden',
+			statusCode: 403,
+		},
 		status: 403,
 	});
 	await app.close();

--- a/spec/scoped-lifecycle-hook-another-order.test.ts
+++ b/spec/scoped-lifecycle-hook-another-order.test.ts
@@ -5,11 +5,10 @@ import { Injectable, SCOPE } from '../src/injector/injectable/decorator.ts';
 import { Module } from '../src/module/decorator.ts';
 import { Controller, Get } from '../src/router/controller/decorator.ts';
 import { HttpContext } from '../src/router/router.ts';
-import { Inject } from "../src/injector/decorator.ts";
-import { TokenInjector } from "../src/injector/injectable/constructor.ts";
+import { Inject } from '../src/injector/decorator.ts';
+import { TokenInjector } from '../src/injector/injectable/constructor.ts';
 
 Deno.test('Scoped Lifecycle hooks other order', async (testContext) => {
-
 	interface ScopedInjectableInterface {
 		somethingThatMatters: string | null;
 	}
@@ -24,7 +23,6 @@ Deno.test('Scoped Lifecycle hooks other order', async (testContext) => {
 
 	@Injectable()
 	class InjectableUsingScoped {
-
 		constructor(
 			@Inject('SCOPED_TOKEN') public child1: ScopedInjectableInterface,
 		) {

--- a/spec/scoped-lifecycle-hook.test.ts
+++ b/spec/scoped-lifecycle-hook.test.ts
@@ -5,11 +5,10 @@ import { Injectable, SCOPE } from '../src/injector/injectable/decorator.ts';
 import { Module } from '../src/module/decorator.ts';
 import { Controller, Get } from '../src/router/controller/decorator.ts';
 import { HttpContext } from '../src/router/router.ts';
-import { Inject } from "../src/injector/decorator.ts";
-import { TokenInjector } from "../src/injector/injectable/constructor.ts";
+import { Inject } from '../src/injector/decorator.ts';
+import { TokenInjector } from '../src/injector/injectable/constructor.ts';
 
 Deno.test('Scoped Lifecycle hooks', async (testContext) => {
-
 	interface ScopedInjectableInterface {
 		somethingThatMatters: string | null;
 	}
@@ -24,7 +23,6 @@ Deno.test('Scoped Lifecycle hooks', async (testContext) => {
 
 	@Injectable()
 	class InjectableUsingScoped {
-
 		constructor(
 			@Inject('SCOPED_TOKEN') public child1: ScopedInjectableInterface,
 		) {

--- a/src/exception/http/exceptions.ts
+++ b/src/exception/http/exceptions.ts
@@ -14,38 +14,38 @@ export class ForbiddenException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Forbidden',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.FORBIDDEN,
+			),
 			HttpStatus.FORBIDDEN,
-		  ),
-		  HttpStatus.FORBIDDEN,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class BadRequestException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Bad Request'
+		descriptionOrOptions: string | HttpExceptionOptions = 'Bad Request',
 	) {
-		const { description, httpExceptionOptions } =
-		HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	  super(
-		HttpException.createBody(
-		  objectOrError,
-		  description,
-		  HttpStatus.BAD_REQUEST,
-		),
-		HttpStatus.BAD_REQUEST,
-		httpExceptionOptions,
-	  );
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+		super(
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.BAD_REQUEST,
+			),
+			HttpStatus.BAD_REQUEST,
+			httpExceptionOptions,
+		);
 	}
 }
 
@@ -53,20 +53,20 @@ export class UnauthorizedException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Unauthorized',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.UNAUTHORIZED,
+			),
 			HttpStatus.UNAUTHORIZED,
-		  ),
-		  HttpStatus.UNAUTHORIZED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 // do not exists in nestJS
@@ -74,549 +74,561 @@ export class PaymentRequiredException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Payment required',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.PAYMENT_REQUIRED,
+			),
 			HttpStatus.PAYMENT_REQUIRED,
-		  ),
-		  HttpStatus.PAYMENT_REQUIRED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class NotFoundException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Not Found',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.NOT_FOUND,
+			),
 			HttpStatus.NOT_FOUND,
-		  ),
-		  HttpStatus.NOT_FOUND,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class MethodNotAllowedException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Method Not Allowed',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.METHOD_NOT_ALLOWED,
+			),
 			HttpStatus.METHOD_NOT_ALLOWED,
-		  ),
-		  HttpStatus.METHOD_NOT_ALLOWED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class NotAcceptableException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Not Acceptable',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.NOT_ACCEPTABLE,
+			),
 			HttpStatus.NOT_ACCEPTABLE,
-		  ),
-		  HttpStatus.NOT_ACCEPTABLE,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 // do not exists in nestJS
 export class ProxyAuthenticationRequiredException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Proxy authentication required',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+		descriptionOrOptions: string | HttpExceptionOptions =
+			'Proxy authentication required',
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.PROXY_AUTHENTICATION_REQUIRED,
+			),
 			HttpStatus.PROXY_AUTHENTICATION_REQUIRED,
-		  ),
-		  HttpStatus.PROXY_AUTHENTICATION_REQUIRED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class RequestTimeoutException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Request Timeout',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.REQUEST_TIMEOUT,
+			),
 			HttpStatus.REQUEST_TIMEOUT,
-		  ),
-		  HttpStatus.REQUEST_TIMEOUT,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class ConflictException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Conflict',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(objectOrError, description, HttpStatus.CONFLICT),
-		  HttpStatus.CONFLICT,
-		  httpExceptionOptions,
+			HttpException.createBody(objectOrError, description, HttpStatus.CONFLICT),
+			HttpStatus.CONFLICT,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class GoneException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Gone',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(objectOrError, description, HttpStatus.GONE),
-		  HttpStatus.GONE,
-		  httpExceptionOptions,
+			HttpException.createBody(objectOrError, description, HttpStatus.GONE),
+			HttpStatus.GONE,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class LengthRequiredException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Length required',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(objectOrError, description, HttpStatus.LENGTH_REQUIRED),
-		  HttpStatus.LENGTH_REQUIRED,
-		  httpExceptionOptions,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.LENGTH_REQUIRED,
+			),
+			HttpStatus.LENGTH_REQUIRED,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class PreconditionFailedException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Precondition Failed',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.PRECONDITION_FAILED,
+			),
 			HttpStatus.PRECONDITION_FAILED,
-		  ),
-		  HttpStatus.PRECONDITION_FAILED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class PayloadTooLargeException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Payload too large',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.PAYLOAD_TOO_LARGE,
+			),
 			HttpStatus.PAYLOAD_TOO_LARGE,
-		  ),
-		  HttpStatus.PAYLOAD_TOO_LARGE,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class URITooLongException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'URI too long',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.URI_TOO_LONG,
+			),
 			HttpStatus.URI_TOO_LONG,
-		  ),
-		  HttpStatus.URI_TOO_LONG,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class UnsupportedMediaTypeException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Unsupported media type',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+		descriptionOrOptions: string | HttpExceptionOptions =
+			'Unsupported media type',
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+			),
 			HttpStatus.UNSUPPORTED_MEDIA_TYPE,
-		  ),
-		  HttpStatus.UNSUPPORTED_MEDIA_TYPE,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class RequestedRangeNotSatisfiableException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Requested range not statisfiable',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+		descriptionOrOptions: string | HttpExceptionOptions =
+			'Requested range not statisfiable',
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
+			),
 			HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
-		  ),
-		  HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class ExpectationFailedException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Expectation failed',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.EXPECTATION_FAILED,
+			),
 			HttpStatus.EXPECTATION_FAILED,
-		  ),
-		  HttpStatus.EXPECTATION_FAILED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class IAmATeapotException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'I am a teapot',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.I_AM_A_TEAPOT,
+			),
 			HttpStatus.I_AM_A_TEAPOT,
-		  ),
-		  HttpStatus.I_AM_A_TEAPOT,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class MisdirectedException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Misdirected',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.MISDIRECTED,
+			),
 			HttpStatus.MISDIRECTED,
-		  ),
-		  HttpStatus.MISDIRECTED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class UnprocessableEntityException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Unprocessable entity',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+		descriptionOrOptions: string | HttpExceptionOptions =
+			'Unprocessable entity',
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.UNPROCESSABLE_ENTITY,
+			),
 			HttpStatus.UNPROCESSABLE_ENTITY,
-		  ),
-		  HttpStatus.UNPROCESSABLE_ENTITY,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class FailedDependencyException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Failed dependency',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.FAILED_DEPENDENCY,
+			),
 			HttpStatus.FAILED_DEPENDENCY,
-		  ),
-		  HttpStatus.FAILED_DEPENDENCY,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class PreconditionRequiredException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Precondition required',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+		descriptionOrOptions: string | HttpExceptionOptions =
+			'Precondition required',
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.PRECONDITION_REQUIRED,
+			),
 			HttpStatus.PRECONDITION_REQUIRED,
-		  ),
-		  HttpStatus.PRECONDITION_REQUIRED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class TooManyRequestsException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Too many requests',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.TOO_MANY_REQUESTS,
+			),
 			HttpStatus.TOO_MANY_REQUESTS,
-		  ),
-		  HttpStatus.TOO_MANY_REQUESTS,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class InternalServerErrorException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Internal server error',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+		descriptionOrOptions: string | HttpExceptionOptions =
+			'Internal server error',
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.INTERNAL_SERVER_ERROR,
+			),
 			HttpStatus.INTERNAL_SERVER_ERROR,
-		  ),
-		  HttpStatus.INTERNAL_SERVER_ERROR,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class NotImplementedException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Not implemented',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.NOT_IMPLEMENTED,
+			),
 			HttpStatus.NOT_IMPLEMENTED,
-		  ),
-		  HttpStatus.NOT_IMPLEMENTED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class BadGatewayException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Bad gateway',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.BAD_GATEWAY,
+			),
 			HttpStatus.BAD_GATEWAY,
-		  ),
-		  HttpStatus.BAD_GATEWAY,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class ServiceUnavailableException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Service unavailable',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.SERVICE_UNAVAILABLE,
+			),
 			HttpStatus.SERVICE_UNAVAILABLE,
-		  ),
-		  HttpStatus.SERVICE_UNAVAILABLE,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class GatewayTimeoutException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Gateway timeout',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.GATEWAY_TIMEOUT,
+			),
 			HttpStatus.GATEWAY_TIMEOUT,
-		  ),
-		  HttpStatus.GATEWAY_TIMEOUT,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class HttpVersionNotSupportedException extends HttpException {
 	constructor(
 		objectOrError?: string | object | any,
-		descriptionOrOptions: string | HttpExceptionOptions = 'Http version not supported',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+		descriptionOrOptions: string | HttpExceptionOptions =
+			'Http version not supported',
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
+			),
 			HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
-		  ),
-		  HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
-	  }
+	}
 }
 
 export class NotValidBodyException<T> extends HttpException {
 	reasons: T;
 
-	constructor(reasons: T,
+	constructor(
+		reasons: T,
 		objectOrError?: string | object | any,
 		descriptionOrOptions: string | HttpExceptionOptions = 'Body bad formatted',
-	  ) {
-		const { description, httpExceptionOptions } =
-		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
-	
+	) {
+		const { description, httpExceptionOptions } = HttpException
+			.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
 		super(
-		  HttpException.createBody(
-			objectOrError,
-			description,
+			HttpException.createBody(
+				objectOrError,
+				description,
+				HttpStatus.BAD_REQUEST,
+			),
 			HttpStatus.BAD_REQUEST,
-		  ),
-		  HttpStatus.BAD_REQUEST,
-		  httpExceptionOptions,
+			httpExceptionOptions,
 		);
 		this.reasons = reasons;
-	  }
+	}
 }

--- a/src/exception/http/exceptions.ts
+++ b/src/exception/http/exceptions.ts
@@ -1,202 +1,622 @@
-import { HTTP_STATUS } from './enum.ts';
+// deno-lint-ignore-file no-explicit-any ban-types
+import { HTTP_STATUS as HttpStatus } from './enum.ts';
+// import { HTTP_STATUS } from './enum.ts';
+import { HttpException, HttpExceptionOptions } from './http.exception.ts';
 
-export class HttpException extends Error {
-	constructor(readonly status: number, description: string) {
-		super(`${status} - ${description}`);
-		this.name = this.constructor.name;
-	}
-}
+// export class HttpException extends Error {
+// 	constructor(readonly status: number, description: string) {
+// 		super(`${status} - ${description}`);
+// 		this.name = this.constructor.name;
+// 	}
+// }
 
 export class ForbiddenException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.FORBIDDEN, 'Forbidden');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Forbidden',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.FORBIDDEN,
+		  ),
+		  HttpStatus.FORBIDDEN,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class BadRequestException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.BAD_REQUEST, 'Bad request');
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Bad Request'
+	) {
+		const { description, httpExceptionOptions } =
+		HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	  super(
+		HttpException.createBody(
+		  objectOrError,
+		  description,
+		  HttpStatus.BAD_REQUEST,
+		),
+		HttpStatus.BAD_REQUEST,
+		httpExceptionOptions,
+	  );
 	}
 }
 
 export class UnauthorizedException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.UNAUTHORIZED, 'Unauthorized');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Unauthorized',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.UNAUTHORIZED,
+		  ),
+		  HttpStatus.UNAUTHORIZED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
+// do not exists in nestJS
 export class PaymentRequiredException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.PAYMENT_REQUIRED, 'Payment required');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Payment required',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.PAYMENT_REQUIRED,
+		  ),
+		  HttpStatus.PAYMENT_REQUIRED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class NotFoundException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.NOT_FOUND, 'Not found');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Not Found',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.NOT_FOUND,
+		  ),
+		  HttpStatus.NOT_FOUND,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class MethodNotAllowedException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.METHOD_NOT_ALLOWED, 'Method not allowed');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Method Not Allowed',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.METHOD_NOT_ALLOWED,
+		  ),
+		  HttpStatus.METHOD_NOT_ALLOWED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class NotAcceptableException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.NOT_ACCEPTABLE, 'Not acceptable');
-	}
-}
-
-export class ProxyAuthenticationRequiredException extends HttpException {
-	constructor() {
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Not Acceptable',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
 		super(
-			HTTP_STATUS.PROXY_AUTHENTICATION_REQUIRED,
-			'Proxy authentication required',
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.NOT_ACCEPTABLE,
+		  ),
+		  HttpStatus.NOT_ACCEPTABLE,
+		  httpExceptionOptions,
 		);
-	}
+	  }
+}
+// do not exists in nestJS
+export class ProxyAuthenticationRequiredException extends HttpException {
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Proxy authentication required',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.PROXY_AUTHENTICATION_REQUIRED,
+		  ),
+		  HttpStatus.PROXY_AUTHENTICATION_REQUIRED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class RequestTimeoutException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.REQUEST_TIMEOUT, 'Request timeout');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Request Timeout',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.REQUEST_TIMEOUT,
+		  ),
+		  HttpStatus.REQUEST_TIMEOUT,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class ConflictException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.CONFLICT, 'Conflict');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Conflict',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(objectOrError, description, HttpStatus.CONFLICT),
+		  HttpStatus.CONFLICT,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class GoneException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.GONE, 'Gone');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Gone',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(objectOrError, description, HttpStatus.GONE),
+		  HttpStatus.GONE,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class LengthRequiredException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.LENGTH_REQUIRED, 'Length required');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Length required',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(objectOrError, description, HttpStatus.LENGTH_REQUIRED),
+		  HttpStatus.LENGTH_REQUIRED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class PreconditionFailedException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.PRECONDITION_FAILED, 'Precondition failed');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Precondition Failed',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.PRECONDITION_FAILED,
+		  ),
+		  HttpStatus.PRECONDITION_FAILED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class PayloadTooLargeException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.PAYLOAD_TOO_LARGE, 'Payload too large');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Payload too large',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.PAYLOAD_TOO_LARGE,
+		  ),
+		  HttpStatus.PAYLOAD_TOO_LARGE,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class URITooLongException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.URI_TOO_LONG, 'URI too long');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'URI too long',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.URI_TOO_LONG,
+		  ),
+		  HttpStatus.URI_TOO_LONG,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class UnsupportedMediaTypeException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE, 'Unsupported media type');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Unsupported media type',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+		  ),
+		  HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class RequestedRangeNotSatisfiableException extends HttpException {
-	constructor() {
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Requested range not statisfiable',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
 		super(
-			HTTP_STATUS.REQUESTED_RANGE_NOT_SATISFIABLE,
-			'Requested range not statisfiable',
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
+		  ),
+		  HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
+		  httpExceptionOptions,
 		);
-	}
+	  }
 }
 
 export class ExpectationFailedException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.EXPECTATION_FAILED, 'Expectation failed');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Expectation failed',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.EXPECTATION_FAILED,
+		  ),
+		  HttpStatus.EXPECTATION_FAILED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class IAmATeapotException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.I_AM_A_TEAPOT, 'I am a teapot');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'I am a teapot',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.I_AM_A_TEAPOT,
+		  ),
+		  HttpStatus.I_AM_A_TEAPOT,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class MisdirectedException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.MISDIRECTED, 'Misdirected');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Misdirected',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.MISDIRECTED,
+		  ),
+		  HttpStatus.MISDIRECTED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class UnprocessableEntityException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.UNPROCESSABLE_ENTITY, 'Unprocessable entity');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Unprocessable entity',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.UNPROCESSABLE_ENTITY,
+		  ),
+		  HttpStatus.UNPROCESSABLE_ENTITY,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class FailedDependencyException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.FAILED_DEPENDENCY, 'Failed dependency');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Failed dependency',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.FAILED_DEPENDENCY,
+		  ),
+		  HttpStatus.FAILED_DEPENDENCY,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class PreconditionRequiredException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.PRECONDITION_REQUIRED, 'Precondition required');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Precondition required',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.PRECONDITION_REQUIRED,
+		  ),
+		  HttpStatus.PRECONDITION_REQUIRED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class TooManyRequestsException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.TOO_MANY_REQUESTS, 'Too many requests');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Too many requests',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.TOO_MANY_REQUESTS,
+		  ),
+		  HttpStatus.TOO_MANY_REQUESTS,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class InternalServerErrorException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.INTERNAL_SERVER_ERROR, 'Internal server error');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Internal server error',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.INTERNAL_SERVER_ERROR,
+		  ),
+		  HttpStatus.INTERNAL_SERVER_ERROR,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class NotImplementedException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.NOT_IMPLEMENTED, 'Not implemented');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Not implemented',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.NOT_IMPLEMENTED,
+		  ),
+		  HttpStatus.NOT_IMPLEMENTED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class BadGatewayException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.BAD_GATEWAY, 'Bad gateway');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Bad gateway',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.BAD_GATEWAY,
+		  ),
+		  HttpStatus.BAD_GATEWAY,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class ServiceUnavailableException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.SERVICE_UNAVAILABLE, 'Service unavailable');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Service unavailable',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.SERVICE_UNAVAILABLE,
+		  ),
+		  HttpStatus.SERVICE_UNAVAILABLE,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class GatewayTimeoutException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.GATEWAY_TIMEOUT, 'Gateway timeout');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Gateway timeout',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.GATEWAY_TIMEOUT,
+		  ),
+		  HttpStatus.GATEWAY_TIMEOUT,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class HttpVersionNotSupportedException extends HttpException {
-	constructor() {
-		super(HTTP_STATUS.HTTP_VERSION_NOT_SUPPORTED, 'Http version not supported');
-	}
+	constructor(
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Http version not supported',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
+		  ),
+		  HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
+		  httpExceptionOptions,
+		);
+	  }
 }
 
 export class NotValidBodyException<T> extends HttpException {
 	reasons: T;
-	constructor(reasons: T) {
-		super(HTTP_STATUS.BAD_REQUEST, 'Body bad formatted');
+
+	constructor(reasons: T,
+		objectOrError?: string | object | any,
+		descriptionOrOptions: string | HttpExceptionOptions = 'Body bad formatted',
+	  ) {
+		const { description, httpExceptionOptions } =
+		  HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+	
+		super(
+		  HttpException.createBody(
+			objectOrError,
+			description,
+			HttpStatus.BAD_REQUEST,
+		  ),
+		  HttpStatus.BAD_REQUEST,
+		  httpExceptionOptions,
+		);
 		this.reasons = reasons;
-	}
+	  }
 }

--- a/src/exception/http/http.exception.ts
+++ b/src/exception/http/http.exception.ts
@@ -1,9 +1,3 @@
-// import {
-//   HttpExceptionBody,
-//   HttpExceptionBodyMessage,
-// } from '../interfaces/http/http-exception-body.interface';
-// import { isObject, isString } from '../utils/shared.utils';
-
 import {
 	HttpExceptionBody,
 	HttpExceptionBodyMessage,
@@ -30,7 +24,8 @@ export class HttpException extends Error {
 	// }
 
 	constructor(
-		response: string | Record<string, unknown>,
+		// deno-lint-ignore no-explicit-any
+		response: string | Record<string, any>,
 		status: number,
 		options?: HttpExceptionOptions,
 	) {

--- a/src/exception/http/http.exception.ts
+++ b/src/exception/http/http.exception.ts
@@ -4,151 +4,153 @@
 // } from '../interfaces/http/http-exception-body.interface';
 // import { isObject, isString } from '../utils/shared.utils';
 
-import { HttpExceptionBody, HttpExceptionBodyMessage } from "../../interfaces/http/http-exception-body.interface.ts";
-import { isObject, isString } from "../../shared.utils.TS";
+import {
+	HttpExceptionBody,
+	HttpExceptionBodyMessage,
+} from '../../interfaces/http/http-exception-body.interface.ts';
+import { isObject, isString } from '../../shared.utils.TS';
 
 export interface HttpExceptionOptions {
-  /** original cause of the error */
-  cause?: unknown;
-  description?: string;
+	/** original cause of the error */
+	cause?: unknown;
+	description?: string;
 }
 
 export interface DescriptionAndOptions {
-  description?: string;
-  httpExceptionOptions?: HttpExceptionOptions;
+	description?: string;
+	httpExceptionOptions?: HttpExceptionOptions;
 }
 
 export class HttpException extends Error {
-  private readonly response: string | Record<string, any>;
-  private readonly status: number;
-  private readonly options?: HttpExceptionOptions;
+	private readonly response: string | Record<string, unknown>;
+	private readonly status: number;
+	private readonly options?: HttpExceptionOptions;
 
+	// constructor(readonly status: number, description: string) {
+	// }
 
- 	// constructor(readonly status: number, description: string) {
-  // }
+	constructor(
+		response: string | Record<string, unknown>,
+		status: number,
+		options?: HttpExceptionOptions,
+	) {
+		super();
+		this.response = response;
+		this.status = status;
+		this.options = options;
+		this.initMessage();
+		this.initName();
+		this.initCause();
+	}
 
-  constructor(
-    response: string | Record<string, any>,
-    status: number,
-    options?: HttpExceptionOptions,
-  ) {
-    super();
-    this.response = response;
-    this.status = status;
-    this.options = options;
-    this.initMessage();
-    this.initName();
-    this.initCause();
-  }
+	public cause: unknown;
 
-  public cause: unknown;
+	public initCause(): void {
+		if (this.options?.cause) {
+			this.cause = this.options.cause;
+			return;
+		}
+	}
 
-  public initCause(): void {
-    if (this.options?.cause) {
-      this.cause = this.options.cause;
-      return;
-    }
-  }
+	public initMessage() {
+		if (isString(this.response)) {
+			this.message = this.response;
+		} else if (
+			isObject(this.response) &&
+			isString((this.response as Record<string, unknown>).message)
+		) {
+			this.message = (this.response as { message: string }).message;
+		} else if (this.constructor) {
+			this.message =
+				this.constructor.name.match(/[A-Z][a-z]+|[0-9]+/g)?.join(' ') ??
+					'Error';
+		}
+	}
 
-  public initMessage() {
-    if (isString(this.response)) {
-      this.message = this.response;
-    } else if (
-      isObject(this.response) &&
-      isString((this.response as Record<string, any>).message)
-    ) {
-      this.message = (this.response as Record<string, any>).message;
-    } else if (this.constructor) {
-      this.message =
-        this.constructor.name.match(/[A-Z][a-z]+|[0-9]+/g)?.join(' ') ??
-        'Error';
-    }
-  }
+	public initName(): void {
+		this.name = this.constructor.name;
+	}
 
-  public initName(): void {
-    this.name = this.constructor.name;
-  }
+	public getResponse(): string | Record<string, unknown> {
+		return this.response;
+	}
 
-  public getResponse(): string | object {
-    return this.response;
-  }
+	public getStatus(): number {
+		return this.status;
+	}
 
-  public getStatus(): number {
-    return this.status;
-  }
+	public static createBody(
+		nil: null | '',
+		message?: HttpExceptionBodyMessage,
+		statusCode?: number,
+	): HttpExceptionBody;
 
-  public static createBody(
-    nil: null | '',
-    message?: HttpExceptionBodyMessage,
-    statusCode?: number,
-  ): HttpExceptionBody;
+	public static createBody(
+		message: HttpExceptionBodyMessage,
+		error: string,
+		statusCode: number,
+	): HttpExceptionBody;
 
-  public static createBody(
-    message: HttpExceptionBodyMessage,
-    error: string,
-    statusCode: number,
-  ): HttpExceptionBody;
+	public static createBody<Body extends Record<string, unknown>>(
+		custom: Body,
+	): Body;
 
-  public static createBody<Body extends Record<string, unknown>>(
-    custom: Body,
-  ): Body;
+	public static createBody<Body extends Record<string, unknown>>(
+		arg0: null | HttpExceptionBodyMessage | Body,
+		arg1?: HttpExceptionBodyMessage | string,
+		statusCode?: number,
+	): HttpExceptionBody | Body {
+		if (!arg0) {
+			return {
+				message: arg1 || 'Internal Danet error',
+				statusCode: statusCode || 500,
+			};
+		}
 
-  public static createBody<Body extends Record<string, unknown>>(
-    arg0: null | HttpExceptionBodyMessage | Body,
-    arg1?: HttpExceptionBodyMessage | string,
-    statusCode?: number,
-  ): HttpExceptionBody | Body {
-    if (!arg0) {
-      return {
-        message: arg1 || "Internal Danet error",
-        statusCode: statusCode || 500,
-      };
-    }
+		if (isString(arg0) || Array.isArray(arg0)) {
+			return {
+				message: arg0 || 'Internal Danet error',
+				error: arg1 as string,
+				statusCode: statusCode || 500,
+			};
+		}
 
-    if (isString(arg0) || Array.isArray(arg0)) {
-      return {
-        message: arg0 || "Internal Danet error",
-        error: arg1 as string,
-        statusCode: statusCode || 500,
-      };
-    }
+		return arg0;
+	}
 
-    return arg0;
-  }
+	public static getDescriptionFrom(
+		descriptionOrOptions: string | HttpExceptionOptions,
+	): string {
+		return isString(descriptionOrOptions)
+			? descriptionOrOptions as string
+			: descriptionOrOptions?.description as string;
+	}
 
-  public static getDescriptionFrom(
-    descriptionOrOptions: string | HttpExceptionOptions,
-  ): string {
-    return isString(descriptionOrOptions)
-      ? descriptionOrOptions as string
-      : descriptionOrOptions?.description as string;
-  }
+	public static getHttpExceptionOptionsFrom(
+		descriptionOrOptions: string | HttpExceptionOptions,
+	): HttpExceptionOptions {
+		return isString(descriptionOrOptions) ? {} : descriptionOrOptions;
+	}
 
-  public static getHttpExceptionOptionsFrom(
-    descriptionOrOptions: string | HttpExceptionOptions,
-  ): HttpExceptionOptions {
-    return isString(descriptionOrOptions) ? {} : descriptionOrOptions;
-  }
+	/**
+	 * Utility method used to extract the error description and httpExceptionOptions from the given argument.
+	 * This is used by inheriting classes to correctly parse both options.
+	 * @returns the error description and the httpExceptionOptions as an object.
+	 */
+	public static extractDescriptionAndOptionsFrom(
+		descriptionOrOptions: string | HttpExceptionOptions,
+	): DescriptionAndOptions {
+		const description = isString(descriptionOrOptions)
+			? descriptionOrOptions
+			: descriptionOrOptions?.description;
 
-  /**
-   * Utility method used to extract the error description and httpExceptionOptions from the given argument.
-   * This is used by inheriting classes to correctly parse both options.
-   * @returns the error description and the httpExceptionOptions as an object.
-   */
-  public static extractDescriptionAndOptionsFrom(
-    descriptionOrOptions: string | HttpExceptionOptions,
-  ): DescriptionAndOptions {
-    const description = isString(descriptionOrOptions)
-      ? descriptionOrOptions
-      : descriptionOrOptions?.description;
+		const httpExceptionOptions = isString(descriptionOrOptions)
+			? {}
+			: descriptionOrOptions;
 
-    const httpExceptionOptions = isString(descriptionOrOptions)
-      ? {}
-      : descriptionOrOptions;
-
-    return {
-      description,
-      httpExceptionOptions,
-    };
-  }
+		return {
+			description,
+			httpExceptionOptions,
+		};
+	}
 }

--- a/src/exception/http/http.exception.ts
+++ b/src/exception/http/http.exception.ts
@@ -1,0 +1,154 @@
+// import {
+//   HttpExceptionBody,
+//   HttpExceptionBodyMessage,
+// } from '../interfaces/http/http-exception-body.interface';
+// import { isObject, isString } from '../utils/shared.utils';
+
+import { HttpExceptionBody, HttpExceptionBodyMessage } from "../../interfaces/http/http-exception-body.interface.ts";
+import { isObject, isString } from "../../shared.utils.TS";
+
+export interface HttpExceptionOptions {
+  /** original cause of the error */
+  cause?: unknown;
+  description?: string;
+}
+
+export interface DescriptionAndOptions {
+  description?: string;
+  httpExceptionOptions?: HttpExceptionOptions;
+}
+
+export class HttpException extends Error {
+  private readonly response: string | Record<string, any>;
+  private readonly status: number;
+  private readonly options?: HttpExceptionOptions;
+
+
+ 	// constructor(readonly status: number, description: string) {
+  // }
+
+  constructor(
+    response: string | Record<string, any>,
+    status: number,
+    options?: HttpExceptionOptions,
+  ) {
+    super();
+    this.response = response;
+    this.status = status;
+    this.options = options;
+    this.initMessage();
+    this.initName();
+    this.initCause();
+  }
+
+  public cause: unknown;
+
+  public initCause(): void {
+    if (this.options?.cause) {
+      this.cause = this.options.cause;
+      return;
+    }
+  }
+
+  public initMessage() {
+    if (isString(this.response)) {
+      this.message = this.response;
+    } else if (
+      isObject(this.response) &&
+      isString((this.response as Record<string, any>).message)
+    ) {
+      this.message = (this.response as Record<string, any>).message;
+    } else if (this.constructor) {
+      this.message =
+        this.constructor.name.match(/[A-Z][a-z]+|[0-9]+/g)?.join(' ') ??
+        'Error';
+    }
+  }
+
+  public initName(): void {
+    this.name = this.constructor.name;
+  }
+
+  public getResponse(): string | object {
+    return this.response;
+  }
+
+  public getStatus(): number {
+    return this.status;
+  }
+
+  public static createBody(
+    nil: null | '',
+    message?: HttpExceptionBodyMessage,
+    statusCode?: number,
+  ): HttpExceptionBody;
+
+  public static createBody(
+    message: HttpExceptionBodyMessage,
+    error: string,
+    statusCode: number,
+  ): HttpExceptionBody;
+
+  public static createBody<Body extends Record<string, unknown>>(
+    custom: Body,
+  ): Body;
+
+  public static createBody<Body extends Record<string, unknown>>(
+    arg0: null | HttpExceptionBodyMessage | Body,
+    arg1?: HttpExceptionBodyMessage | string,
+    statusCode?: number,
+  ): HttpExceptionBody | Body {
+    if (!arg0) {
+      return {
+        message: arg1 || "Internal Danet error",
+        statusCode: statusCode || 500,
+      };
+    }
+
+    if (isString(arg0) || Array.isArray(arg0)) {
+      return {
+        message: arg0 || "Internal Danet error",
+        error: arg1 as string,
+        statusCode: statusCode || 500,
+      };
+    }
+
+    return arg0;
+  }
+
+  public static getDescriptionFrom(
+    descriptionOrOptions: string | HttpExceptionOptions,
+  ): string {
+    return isString(descriptionOrOptions)
+      ? descriptionOrOptions as string
+      : descriptionOrOptions?.description as string;
+  }
+
+  public static getHttpExceptionOptionsFrom(
+    descriptionOrOptions: string | HttpExceptionOptions,
+  ): HttpExceptionOptions {
+    return isString(descriptionOrOptions) ? {} : descriptionOrOptions;
+  }
+
+  /**
+   * Utility method used to extract the error description and httpExceptionOptions from the given argument.
+   * This is used by inheriting classes to correctly parse both options.
+   * @returns the error description and the httpExceptionOptions as an object.
+   */
+  public static extractDescriptionAndOptionsFrom(
+    descriptionOrOptions: string | HttpExceptionOptions,
+  ): DescriptionAndOptions {
+    const description = isString(descriptionOrOptions)
+      ? descriptionOrOptions
+      : descriptionOrOptions?.description;
+
+    const httpExceptionOptions = isString(descriptionOrOptions)
+      ? {}
+      : descriptionOrOptions;
+
+    return {
+      description,
+      httpExceptionOptions,
+    };
+  }
+}

--- a/src/exception/http/mod.ts
+++ b/src/exception/http/mod.ts
@@ -1,4 +1,6 @@
 // created from ctix
 
 export * from './enum.ts';
+// alias to be export compatible with nestJS
+export { HTTP_STATUS as HttpStatus } from './enum.ts';
 export * from './exceptions.ts';

--- a/src/injector/injector.ts
+++ b/src/injector/injector.ts
@@ -27,7 +27,10 @@ export class Injector {
 		Constructor | string,
 		Constructor
 	>();
-	private contextInjectables = new Map<string, Map<Constructor | string, unknown>>();
+	private contextInjectables = new Map<
+		string,
+		Map<Constructor | string, unknown>
+	>();
 
 	public getAll() {
 		return this.resolved;
@@ -62,8 +65,12 @@ export class Injector {
 
 	public addAvailableInjectable(injectables: InjectableConstructor[]) {
 		for (const injectable of injectables) {
-			const actualKey = injectable instanceof TokenInjector ? injectable.token : injectable;
-			const actualType = injectable instanceof TokenInjector ? injectable.useClass : injectable;
+			const actualKey = injectable instanceof TokenInjector
+				? injectable.token
+				: injectable;
+			const actualType = injectable instanceof TokenInjector
+				? injectable.useClass
+				: injectable;
 			this.availableTypes.set(actualKey, actualType);
 		}
 	}
@@ -125,7 +132,9 @@ export class Injector {
 		token?: string,
 	) {
 		const actualType = Type instanceof TokenInjector ? Type.useClass : Type;
-		const actualKey = Type instanceof TokenInjector ? Type.token : (token ?? Type);
+		const actualKey = Type instanceof TokenInjector
+			? Type.token
+			: (token ?? Type);
 		const dependencies = this.getDependencies(actualType);
 
 		if (this.resolved.has(actualType)) {
@@ -137,17 +146,24 @@ export class Injector {
 			injectionData,
 			actualType,
 		);
-		let canBeSingleton = injectableMetadata?.scope !== SCOPE.REQUEST && injectableMetadata?.scope !== SCOPE.TRANSIENT;
+		let canBeSingleton = injectableMetadata?.scope !== SCOPE.REQUEST &&
+			injectableMetadata?.scope !== SCOPE.TRANSIENT;
 		if (canBeSingleton) {
 			for (const [idx, Dep] of dependencies.entries()) {
 				const token = this.getParamToken(actualType, idx);
 				const type = this.resolvedTypes.get(token ?? Dep);
-				const dependencyInjectableMetadata = MetadataHelper.getMetadata<InjectableOption>(
+				const dependencyInjectableMetadata = MetadataHelper.getMetadata<
+					InjectableOption
+				>(
 					injectionData,
 					type,
 				);
-				if (dependencyInjectableMetadata?.scope === SCOPE.REQUEST || dependencyInjectableMetadata?.scope === SCOPE.TRANSIENT)
+				if (
+					dependencyInjectableMetadata?.scope === SCOPE.REQUEST ||
+					dependencyInjectableMetadata?.scope === SCOPE.TRANSIENT
+				) {
 					canBeSingleton = false;
+				}
 			}
 		}
 		if (canBeSingleton) {
@@ -163,10 +179,13 @@ export class Injector {
 			this.resolved.set(actualKey, () => instance);
 			this.resolvedTypes.set(actualKey, actualType);
 		} else {
-			if (injectableMetadata?.scope !== SCOPE.TRANSIENT && injectableMetadata?.scope !== SCOPE.REQUEST) {
+			if (
+				injectableMetadata?.scope !== SCOPE.TRANSIENT &&
+				injectableMetadata?.scope !== SCOPE.REQUEST
+			) {
 				MetadataHelper.setMetadata(
 					injectionData,
-					{scope: SCOPE.REQUEST},
+					{ scope: SCOPE.REQUEST },
 					actualType,
 				);
 			}
@@ -177,7 +196,12 @@ export class Injector {
 					ParentConstructor,
 				);
 			}
-			this.setNonSingleton(actualType, actualKey, dependencies, injectableMetadata?.scope === SCOPE.TRANSIENT);
+			this.setNonSingleton(
+				actualType,
+				actualKey,
+				dependencies,
+				injectableMetadata?.scope === SCOPE.TRANSIENT,
+			);
 		}
 	}
 
@@ -192,7 +216,7 @@ export class Injector {
 		Type: Constructor,
 		key: string | InjectableConstructor,
 		dependencies: Array<Constructor>,
-		transient?: boolean
+		transient?: boolean,
 	) {
 		this.resolvedTypes.set(key, Type);
 		this.resolved.set(key, async (ctx?: ExecutionContext) => {
@@ -205,8 +229,9 @@ export class Injector {
 				);
 			}
 			if (ctx && !transient) {
-				if (!this.contextInjectables.has(ctx._id))
+				if (!this.contextInjectables.has(ctx._id)) {
 					this.contextInjectables.set(ctx._id, new Map());
+				}
 				const actualRequestInjectables = this.contextInjectables.get(ctx._id);
 				if (actualRequestInjectables?.has(key)) {
 					return actualRequestInjectables.get(key);
@@ -231,8 +256,7 @@ export class Injector {
 		for (const [idx, Dependency] of Dependencies.entries()) {
 			const token = this.getParamToken(ParentConstructor, idx);
 			if (
-				!this.resolved.get( token ?? Dependency,
-				)
+				!this.resolved.get(token ?? Dependency)
 			) {
 				const type = this.availableTypes.get(token ?? Dependency);
 				if (type) {

--- a/src/interfaces/http/http-exception-body.interface copy.ts
+++ b/src/interfaces/http/http-exception-body.interface copy.ts
@@ -1,0 +1,7 @@
+export type HttpExceptionBodyMessage = string | string[];
+
+export interface HttpExceptionBody {
+  message: HttpExceptionBodyMessage;
+  error?: string;
+  statusCode: number;
+}

--- a/src/interfaces/http/http-exception-body.interface copy.ts
+++ b/src/interfaces/http/http-exception-body.interface copy.ts
@@ -1,7 +1,7 @@
 export type HttpExceptionBodyMessage = string | string[];
 
 export interface HttpExceptionBody {
-  message: HttpExceptionBodyMessage;
-  error?: string;
-  statusCode: number;
+	message: HttpExceptionBodyMessage;
+	error?: string;
+	statusCode: number;
 }

--- a/src/interfaces/http/http-exception-body.interface.ts
+++ b/src/interfaces/http/http-exception-body.interface.ts
@@ -1,0 +1,7 @@
+export type HttpExceptionBodyMessage = string | string[];
+
+export interface HttpExceptionBody {
+  message: HttpExceptionBodyMessage;
+  error?: string;
+  statusCode: number;
+}

--- a/src/interfaces/http/http-exception-body.interface.ts
+++ b/src/interfaces/http/http-exception-body.interface.ts
@@ -1,7 +1,7 @@
 export type HttpExceptionBodyMessage = string | string[];
 
 export interface HttpExceptionBody {
-  message: HttpExceptionBodyMessage;
-  error?: string;
-  statusCode: number;
+	message: HttpExceptionBodyMessage;
+	error?: string;
+	statusCode: number;
 }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -25,7 +25,7 @@ export type Callback = (...args: any[]) => unknown;
 export type HttpContext = Context;
 
 export type ExecutionContext = HttpContext & {
-	_id: string,
+	_id: string;
 	// deno-lint-ignore ban-types
 	getHandler: () => Function;
 	getClass: () => Constructor;
@@ -149,7 +149,11 @@ export class DanetRouter {
 							| string = await controllerInstance[ControllerMethod.name](
 								...params,
 							);
-						await this.sendResponse(response, ControllerMethod, executionContext);
+						await this.sendResponse(
+							response,
+							ControllerMethod,
+							executionContext,
+						);
 					},
 				);
 			} catch (error) {

--- a/src/shared.utils.ts
+++ b/src/shared.utils.ts
@@ -1,53 +1,55 @@
 // imported from nestjs
 /* eslint-disable @typescript-eslint/no-use-before-define */
 export const isUndefined = (obj: unknown): obj is undefined =>
-  typeof obj === 'undefined';
+	typeof obj === 'undefined';
 
-export const isObject = (fn: unknown): fn is object =>
-  !isNil(fn) && typeof fn === 'object';
+export const isObject = (fn: unknown): fn is Record<string, unknown> =>
+	!isNil(fn) && typeof fn === 'object';
 
-export const isPlainObject = (fn: unknown): fn is object => {
-  if (!isObject(fn)) {
-    return false;
-  }
-  const proto = Object.getPrototypeOf(fn);
-  if (proto === null) {
-    return true;
-  }
-  const ctor =
-    Object.prototype.hasOwnProperty.call(proto, 'constructor') &&
-    proto.constructor;
-  return (
-    typeof ctor === 'function' &&
-    ctor instanceof ctor &&
-    Function.prototype.toString.call(ctor) ===
-      Function.prototype.toString.call(Object)
-  );
+export const isPlainObject = (fn: unknown): fn is Record<string, unknown> => {
+	if (!isObject(fn)) {
+		return false;
+	}
+	const proto = Object.getPrototypeOf(fn);
+	if (proto === null) {
+		return true;
+	}
+	const ctor = Object.prototype.hasOwnProperty.call(proto, 'constructor') &&
+		proto.constructor;
+	return (
+		typeof ctor === 'function' &&
+		ctor instanceof ctor &&
+		Function.prototype.toString.call(ctor) ===
+			Function.prototype.toString.call(Object)
+	);
 };
 
 export const addLeadingSlash = (path?: string): string =>
-  path && typeof path === 'string'
-    ? path.charAt(0) !== '/'
-      ? '/' + path
-      : path
-    : '';
+	path && typeof path === 'string'
+		? path.charAt(0) !== '/' ? '/' + path : path
+		: '';
 
 export const normalizePath = (path?: string): string =>
-  path
-    ? path.startsWith('/')
-      ? ('/' + path.replace(/\/+$/, '')).replace(/\/+/g, '/')
-      : '/' + path.replace(/\/+$/, '')
-    : '/';
+	path
+		? path.startsWith('/')
+			? ('/' + path.replace(/\/+$/, '')).replace(/\/+/g, '/')
+			: '/' + path.replace(/\/+$/, '')
+		: '/';
 
 export const stripEndSlash = (path: string) =>
-  path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path;
+	path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path;
 
+// deno-lint-ignore ban-types
 export const isFunction = (val: unknown): val is Function =>
-  typeof val === 'function';
-export const isString = (val: unknown): val is string => typeof val === 'string';
-export const isNumber = (val: unknown): val is number => typeof val === 'number';
+	typeof val === 'function';
+export const isString = (val: unknown): val is string =>
+	typeof val === 'string';
+export const isNumber = (val: unknown): val is number =>
+	typeof val === 'number';
 export const isConstructor = (val: unknown): boolean => val === 'constructor';
 export const isNil = (val: unknown): val is null | undefined =>
-  isUndefined(val) || val === null;
-export const isEmpty = (array: unknown): boolean => !(array && (array as []).length > 0);
-export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol';
+	isUndefined(val) || val === null;
+export const isEmpty = (array: unknown): boolean =>
+	!(array && (array as []).length > 0);
+export const isSymbol = (val: unknown): val is symbol =>
+	typeof val === 'symbol';

--- a/src/shared.utils.ts
+++ b/src/shared.utils.ts
@@ -1,0 +1,53 @@
+// imported from nestjs
+/* eslint-disable @typescript-eslint/no-use-before-define */
+export const isUndefined = (obj: unknown): obj is undefined =>
+  typeof obj === 'undefined';
+
+export const isObject = (fn: unknown): fn is object =>
+  !isNil(fn) && typeof fn === 'object';
+
+export const isPlainObject = (fn: unknown): fn is object => {
+  if (!isObject(fn)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(fn);
+  if (proto === null) {
+    return true;
+  }
+  const ctor =
+    Object.prototype.hasOwnProperty.call(proto, 'constructor') &&
+    proto.constructor;
+  return (
+    typeof ctor === 'function' &&
+    ctor instanceof ctor &&
+    Function.prototype.toString.call(ctor) ===
+      Function.prototype.toString.call(Object)
+  );
+};
+
+export const addLeadingSlash = (path?: string): string =>
+  path && typeof path === 'string'
+    ? path.charAt(0) !== '/'
+      ? '/' + path
+      : path
+    : '';
+
+export const normalizePath = (path?: string): string =>
+  path
+    ? path.startsWith('/')
+      ? ('/' + path.replace(/\/+$/, '')).replace(/\/+/g, '/')
+      : '/' + path.replace(/\/+$/, '')
+    : '/';
+
+export const stripEndSlash = (path: string) =>
+  path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path;
+
+export const isFunction = (val: unknown): val is Function =>
+  typeof val === 'function';
+export const isString = (val: unknown): val is string => typeof val === 'string';
+export const isNumber = (val: unknown): val is number => typeof val === 'number';
+export const isConstructor = (val: unknown): boolean => val === 'constructor';
+export const isNil = (val: unknown): val is null | undefined =>
+  isUndefined(val) || val === null;
+export const isEmpty = (array: unknown): boolean => !(array && (array as []).length > 0);
+export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol';


### PR DESCRIPTION
## Description

nestjs-Zod emit some custom Error message, It need some compatible exceptions.

- Make Exception interface compatible with nestJS
- Add export alias with the Correct nestJS name

---

## Issue Ticket Number

Fixes #64 64

---

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

Nest Error was not the same as Danet Error.

---

# Checklist:

- x] I have run `deno lint` AND `deno fmt` AND `deno task test` and got no
      errors.
- [x] I have followed the contributing guidelines of this project as mentioned
      in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open
      [Pull Requests](https://github.com/Savory/Danet/pulls) for the same
      update/change?
- [x] I have performed a self-review of my own code
