### PR TITLE
fix serveStatic method

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -101,7 +101,6 @@ export class DanetApplication {
 	}
 
 	useStaticAssets(path: string) {
-		console.log(path);
 		this.app.use('*', (context, next: () => Promise<void>) => {
 			const root = path;
 			return (serveStatic({ root })(context, next));

--- a/src/utils/serve-static.ts
+++ b/src/utils/serve-static.ts
@@ -19,7 +19,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
 		// hey tomato love u
 		const url = new URL(c.req.url);
 		const filename = options.path ?? decodeURI(url.pathname);
-		const path = getFilePath({
+		let path = getFilePath({
 			filename: options.rewriteRequestPath
 				? options.rewriteRequestPath(filename)
 				: filename,
@@ -29,6 +29,10 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
 
 		if (!path) return await next();
 
+		if (Deno.build.os !== "windows") {
+			path = `${path}`;
+		}
+		
 		let file;
 
 		try {

--- a/src/utils/serve-static.ts
+++ b/src/utils/serve-static.ts
@@ -19,7 +19,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
 		// hey tomato love u
 		const url = new URL(c.req.url);
 		const filename = options.path ?? decodeURI(url.pathname);
-		let path = getFilePath({
+		const path = getFilePath({
 			filename: options.rewriteRequestPath
 				? options.rewriteRequestPath(filename)
 				: filename,
@@ -28,8 +28,6 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
 		});
 
 		if (!path) return await next();
-
-		path = `/${path}`;
 
 		let file;
 

--- a/src/utils/serve-static.ts
+++ b/src/utils/serve-static.ts
@@ -30,7 +30,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
 		if (!path) return await next();
 
 		if (Deno.build.os !== "windows") {
-			path = `${path}`;
+			path = `/${path}`;
 		}
 		
 		let file;


### PR DESCRIPTION
## Description

This PR fixes a small issue running Danet on windows using the serveStatic method.
![image](https://github.com/Savory/Danet/assets/64388064/a96dacfb-714f-4e7e-b35f-e73bbd2e96b7)

On windows when we use Deno.cwd() we get the full path of the OS starting with C:\\...

This added a \ before C:\\ which resolved in a invalid path :
`/C:\Users\xxxx\Documents\Projects\xxxx/assets/manifest.json`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

# Checklist:

- [x] I have run `deno lint` AND `deno fmt` AND `deno task test` and got no
      errors.
- [x] I have followed the contributing guidelines of this project as mentioned
      in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open
      [Pull Requests](https://github.com/Savory/Danet/pulls) for the same
      update/change?
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes needed to the documentation
