### PR TITLE
feat!: useValue + useClass injectables

### DIFF
--- a/spec/auth-guard.test.ts
+++ b/spec/auth-guard.test.ts
@@ -3,7 +3,6 @@ import { DanetApplication } from '../src/app.ts';
 import { GLOBAL_GUARD } from '../src/guard/constants.ts';
 import { UseGuard } from '../src/guard/decorator.ts';
 import { AuthGuard } from '../src/guard/interface.ts';
-import { TokenInjector } from '../src/injector/injectable/constructor.ts';
 import { Injectable } from '../src/injector/injectable/decorator.ts';
 import { Module } from '../src/module/decorator.ts';
 import { Controller, Get } from '../src/router/controller/decorator.ts';
@@ -133,7 +132,7 @@ class GlobalAuthController {
 @Module({
 	imports: [],
 	controllers: [GlobalAuthController],
-	injectables: [new TokenInjector(GlobalGuard, GLOBAL_GUARD), SimpleService],
+	injectables: [{useClass: GlobalGuard, token: GLOBAL_GUARD}, SimpleService],
 })
 class GlobalAuthModule {}
 

--- a/spec/auth-guard.test.ts
+++ b/spec/auth-guard.test.ts
@@ -132,7 +132,7 @@ class GlobalAuthController {
 @Module({
 	imports: [],
 	controllers: [GlobalAuthController],
-	injectables: [{useClass: GlobalGuard, token: GLOBAL_GUARD}, SimpleService],
+	injectables: [{ useClass: GlobalGuard, token: GLOBAL_GUARD }, SimpleService],
 })
 class GlobalAuthModule {}
 

--- a/spec/injection.test.ts
+++ b/spec/injection.test.ts
@@ -117,7 +117,6 @@ Deno.test('Injection', async (testContext) => {
 							port: '4000',
 						},
 					},
-					// new TokenInjector(DatabaseService, 'DB_SERVICE'),
 				],
 			};
 		}

--- a/spec/injection.test.ts
+++ b/spec/injection.test.ts
@@ -115,8 +115,8 @@ Deno.test('Injection', async (testContext) => {
 						useValue: {
 							name: 'toto',
 							port: '4000',
-						}
-					}
+						},
+					},
 					// new TokenInjector(DatabaseService, 'DB_SERVICE'),
 				],
 			};
@@ -132,7 +132,7 @@ Deno.test('Injection', async (testContext) => {
 			{
 				token: GLOBAL_GUARD,
 				useClass: GlobalGuard,
-			}
+			},
 		],
 	};
 
@@ -154,7 +154,7 @@ Deno.test('Injection', async (testContext) => {
 			assertRejects(() => failingApp.init(ModuleWithMissingProvider));
 		},
 	);
-	
+
 	const app = new DanetApplication();
 	await app.init(FirstModule);
 
@@ -209,9 +209,7 @@ Deno.test('Injection', async (testContext) => {
 			const firstInstance = await app.get<SingletonController>(
 				SingletonController,
 			)!;
-			assertEquals(firstInstance.getMethod(), "toto and 4000");
+			assertEquals(firstInstance.getMethod(), 'toto and 4000');
 		},
 	);
-
-
 });

--- a/spec/lifecycle-hook.test.ts
+++ b/spec/lifecycle-hook.test.ts
@@ -6,7 +6,6 @@ import { Module } from '../src/module/decorator.ts';
 import { Controller } from '../src/router/controller/decorator.ts';
 
 Deno.test('Lifecycle hooks', async (testContext) => {
-
 	let moduleOnAppBootstrapCalled = false;
 
 	@Injectable({ scope: SCOPE.GLOBAL })
@@ -45,7 +44,6 @@ Deno.test('Lifecycle hooks', async (testContext) => {
 		],
 	})
 	class MyModule implements OnAppBootstrap {
-
 		onAppBootstrap(): void | Promise<void> {
 			moduleOnAppBootstrapCalled = true;
 		}
@@ -62,11 +60,9 @@ Deno.test('Lifecycle hooks', async (testContext) => {
 		},
 	);
 
-	await testContext.step('call module onAppBoostrap hook',
-	() => {
+	await testContext.step('call module onAppBoostrap hook', () => {
 		assertEquals(moduleOnAppBootstrapCalled, true);
-	}
-	)
+	});
 
 	await testContext.step(
 		'call global controller onAppBootstrap hook',

--- a/spec/scoped-lifecycle-hook-another-order.test.ts
+++ b/spec/scoped-lifecycle-hook-another-order.test.ts
@@ -62,7 +62,6 @@ Deno.test('Scoped Lifecycle hooks other order', async (testContext) => {
 				token: 'SCOPED_TOKEN',
 				useClass: ScopedInjectable,
 			},
-			// new TokenInjector(ScopedInjectable, 'SCOPED_TOKEN'),
 			InjectableUsingScoped,
 		],
 	})

--- a/spec/scoped-lifecycle-hook-another-order.test.ts
+++ b/spec/scoped-lifecycle-hook-another-order.test.ts
@@ -6,7 +6,6 @@ import { Module } from '../src/module/decorator.ts';
 import { Controller, Get } from '../src/router/controller/decorator.ts';
 import { HttpContext } from '../src/router/router.ts';
 import { Inject } from '../src/injector/decorator.ts';
-import { TokenInjector } from '../src/injector/injectable/constructor.ts';
 
 Deno.test('Scoped Lifecycle hooks other order', async (testContext) => {
 	interface ScopedInjectableInterface {
@@ -59,7 +58,11 @@ Deno.test('Scoped Lifecycle hooks other order', async (testContext) => {
 	@Module({
 		controllers: [ScopedController, SideEffectController],
 		injectables: [
-			new TokenInjector(ScopedInjectable, 'SCOPED_TOKEN'),
+			{
+				token: 'SCOPED_TOKEN',
+				useClass: ScopedInjectable
+			},
+			// new TokenInjector(ScopedInjectable, 'SCOPED_TOKEN'),
 			InjectableUsingScoped,
 		],
 	})

--- a/spec/scoped-lifecycle-hook-another-order.test.ts
+++ b/spec/scoped-lifecycle-hook-another-order.test.ts
@@ -60,7 +60,7 @@ Deno.test('Scoped Lifecycle hooks other order', async (testContext) => {
 		injectables: [
 			{
 				token: 'SCOPED_TOKEN',
-				useClass: ScopedInjectable
+				useClass: ScopedInjectable,
 			},
 			// new TokenInjector(ScopedInjectable, 'SCOPED_TOKEN'),
 			InjectableUsingScoped,

--- a/spec/scoped-lifecycle-hook.test.ts
+++ b/spec/scoped-lifecycle-hook.test.ts
@@ -6,7 +6,6 @@ import { Module } from '../src/module/decorator.ts';
 import { Controller, Get } from '../src/router/controller/decorator.ts';
 import { HttpContext } from '../src/router/router.ts';
 import { Inject } from '../src/injector/decorator.ts';
-import { TokenInjector } from '../src/injector/injectable/constructor.ts';
 
 Deno.test('Scoped Lifecycle hooks', async (testContext) => {
 	interface ScopedInjectableInterface {
@@ -60,7 +59,10 @@ Deno.test('Scoped Lifecycle hooks', async (testContext) => {
 		controllers: [ScopedController, SideEffectController],
 		injectables: [
 			InjectableUsingScoped,
-			new TokenInjector(ScopedInjectable, 'SCOPED_TOKEN'),
+			{
+				useClass: ScopedInjectable,
+				token: 'SCOPED_TOKEN'
+			}
 		],
 	})
 	class ParentBeforeScopedModule {}

--- a/spec/scoped-lifecycle-hook.test.ts
+++ b/spec/scoped-lifecycle-hook.test.ts
@@ -61,8 +61,8 @@ Deno.test('Scoped Lifecycle hooks', async (testContext) => {
 			InjectableUsingScoped,
 			{
 				useClass: ScopedInjectable,
-				token: 'SCOPED_TOKEN'
-			}
+				token: 'SCOPED_TOKEN',
+			},
 		],
 	})
 	class ParentBeforeScopedModule {}

--- a/src/app.ts
+++ b/src/app.ts
@@ -52,21 +52,24 @@ export class DanetApplication {
 		// deno-lint-ignore no-explicit-any
 		const possibleModuleInstance = ModuleInstanceOrConstructor as any;
 		let instance: ModuleInstance;
-		
-		if (!(possibleModuleInstance).imports
-			&& !(possibleModuleInstance).injectables) {
-				instance = new (ModuleInstanceOrConstructor as Constructor)() as ModuleInstance;
-				const metadata: ModuleOptions = MetadataHelper.getMetadata<ModuleOptions>(
-					moduleMetadataKey,
-					ModuleInstanceOrConstructor,
-				);
-				instance.controllers = metadata.controllers;
-				instance.imports = metadata.imports;
-				instance.injectables = metadata.injectables;
+
+		if (
+			!possibleModuleInstance.imports &&
+			!possibleModuleInstance.injectables
+		) {
+			instance =
+				new (ModuleInstanceOrConstructor as Constructor)() as ModuleInstance;
+			const metadata: ModuleOptions = MetadataHelper.getMetadata<ModuleOptions>(
+				moduleMetadataKey,
+				ModuleInstanceOrConstructor,
+			);
+			instance.controllers = metadata.controllers;
+			instance.imports = metadata.imports;
+			instance.injectables = metadata.injectables;
 		} else {
 			instance = ModuleInstanceOrConstructor as ModuleInstance;
 		}
-		
+
 		for (const module in instance?.imports) {
 			// deno-lint-ignore no-explicit-any
 			await this.bootstrap(instance.imports[module as any]);

--- a/src/events/module.ts
+++ b/src/events/module.ts
@@ -23,9 +23,11 @@ export class EventEmitterModule implements OnAppBootstrap, OnAppClose {
 		emitter.unsubscribe();
 	}
 
-        // deno-lint-ignore no-explicit-any
+	// deno-lint-ignore no-explicit-any
 	private registerAvailableEventListeners(injectableInstance: any) {
-		const methods = Object.getOwnPropertyNames(injectableInstance.constructor.prototype);
+		const methods = Object.getOwnPropertyNames(
+			injectableInstance.constructor.prototype,
+		);
 		const emitter = injector.get<EventEmitter>(EventEmitter);
 
 		for (const method of methods) {

--- a/src/injector/injectable/constructor.ts
+++ b/src/injector/injectable/constructor.ts
@@ -1,7 +1,12 @@
 import { Constructor } from '../../utils/constructor.ts';
 
 export type InjectableConstructor = Constructor;
-export class TokenInjector {
-	constructor(public useClass: InjectableConstructor, public token: string) {
-	}
+export type UseClassInjector =  {
+	useClass: InjectableConstructor,
+	token: string,
+}
+export type UseValueInjector =  {
+	// deno-lint-ignore no-explicit-any
+	useValue: any,
+	token: string,
 }

--- a/src/injector/injectable/constructor.ts
+++ b/src/injector/injectable/constructor.ts
@@ -1,12 +1,12 @@
 import { Constructor } from '../../utils/constructor.ts';
 
 export type InjectableConstructor = Constructor;
-export type UseClassInjector =  {
-	useClass: InjectableConstructor,
-	token: string,
-}
-export type UseValueInjector =  {
+export type UseClassInjector = {
+	useClass: InjectableConstructor;
+	token: string;
+};
+export type UseValueInjector = {
 	// deno-lint-ignore no-explicit-any
-	useValue: any,
-	token: string,
-}
+	useValue: any;
+	token: string;
+};

--- a/src/injector/injector.ts
+++ b/src/injector/injector.ts
@@ -67,16 +67,21 @@ export class Injector {
 	}
 
 	public addAvailableInjectable(
-		injectables: (InjectableConstructor | UseClassInjector | UseValueInjector)[],
+		injectables:
+			(InjectableConstructor | UseClassInjector | UseValueInjector)[],
 	) {
 		for (const injectable of injectables) {
-			const { actualKey, actualType, instance } = this.getKeyAndTypeOrInstance(injectable);
+			const { actualKey, actualType, instance } = this.getKeyAndTypeOrInstance(
+				injectable,
+			);
 			this.availableTypes.set(actualKey, actualType ?? instance);
 		}
 	}
 
 	public async registerInjectables(
-		Injectables: Array<InjectableConstructor | UseClassInjector | UseValueInjector>,
+		Injectables: Array<
+			InjectableConstructor | UseClassInjector | UseValueInjector
+		>,
 	) {
 		for (const Provider of Injectables) {
 			await this.resolveInjectable(Provider);
@@ -132,20 +137,22 @@ export class Injector {
 		ParentConstructor?: Constructor,
 		token?: string,
 	) {
-		const { actualType, actualKey, instance } = this.getKeyAndTypeOrInstance(Type, token);
+		const { actualType, actualKey, instance } = this.getKeyAndTypeOrInstance(
+			Type,
+			token,
+		);
 		if (!actualType) {
 			this.resolved.set(actualKey, () => instance);
 			this.resolvedTypes.set(actualKey, instance);
 			this.injectables.push(instance);
 			return;
 		}
-		// deno-lint-ignore no-explicit-any
 		const parameters = this.getParametersTypes(actualType);
 
 		if (this.resolved.has(actualType ?? instance)) {
 			return;
 		}
-		
+
 		if (parameters.length > 0) {
 			await this.resolveDependencies(parameters, actualType);
 		}
@@ -214,16 +221,22 @@ export class Injector {
 		}
 	}
 
-	private getKeyAndTypeOrInstance(Type: InjectableConstructor | UseValueInjector | UseClassInjector, token?: string | undefined) {
+	private getKeyAndTypeOrInstance(
+		Type: InjectableConstructor | UseValueInjector | UseClassInjector,
+		token?: string | undefined,
+	) {
 		if (Object.hasOwn(Type, 'token')) {
 			const actualKey = (Type as UseClassInjector).token;
 			if (Object.hasOwn(Type, 'useClass')) {
-				return { actualKey, actualType: (Type as UseClassInjector).useClass};
+				return { actualKey, actualType: (Type as UseClassInjector).useClass };
 			} else if (Object.hasOwn(Type, 'useValue')) {
-				return { actualKey, instance: (Type as UseValueInjector).useValue};
+				return { actualKey, instance: (Type as UseValueInjector).useValue };
 			}
 		}
-		return { actualKey: (token ?? Type as InjectableConstructor), actualType: Type as InjectableConstructor };
+		return {
+			actualKey: (token ?? Type as InjectableConstructor),
+			actualType: Type as InjectableConstructor,
+		};
 	}
 
 	private getParamToken(Type: Constructor, paramIndex: number) {

--- a/src/module/decorator.ts
+++ b/src/module/decorator.ts
@@ -1,8 +1,6 @@
 import { MetadataHelper } from '../metadata/helper.ts';
 import { ControllerConstructor } from '../router/controller/constructor.ts';
-import {
-	InjectableConstructor,
-} from '../injector/injectable/constructor.ts';
+import { InjectableConstructor } from '../injector/injectable/constructor.ts';
 import { Constructor } from '../utils/constructor.ts';
 import { ModuleConstructor } from './constructor.ts';
 import { UseClassInjector, UseValueInjector } from '../mod.ts';
@@ -10,12 +8,12 @@ import { UseClassInjector, UseValueInjector } from '../mod.ts';
 export class ModuleOptions {
 	imports?: Array<ModuleConstructor | ModuleOptions> = [];
 	controllers?: ControllerConstructor[] = [];
-	injectables?: Array<InjectableConstructor | UseValueInjector | UseClassInjector> = [];
+	injectables?: Array<
+		InjectableConstructor | UseValueInjector | UseClassInjector
+	> = [];
 }
 
-
 export class ModuleInstance extends ModuleOptions {}
-
 
 export const moduleMetadataKey = 'module';
 

--- a/src/module/decorator.ts
+++ b/src/module/decorator.ts
@@ -2,15 +2,15 @@ import { MetadataHelper } from '../metadata/helper.ts';
 import { ControllerConstructor } from '../router/controller/constructor.ts';
 import {
 	InjectableConstructor,
-	TokenInjector,
 } from '../injector/injectable/constructor.ts';
 import { Constructor } from '../utils/constructor.ts';
 import { ModuleConstructor } from './constructor.ts';
+import { UseClassInjector, UseValueInjector } from '../mod.ts';
 
 export class ModuleOptions {
 	imports?: Array<ModuleConstructor | ModuleOptions> = [];
 	controllers?: ControllerConstructor[] = [];
-	injectables?: Array<InjectableConstructor | TokenInjector> = [];
+	injectables?: Array<InjectableConstructor | UseValueInjector | UseClassInjector> = [];
 }
 
 

--- a/src/utils/serve-static.ts
+++ b/src/utils/serve-static.ts
@@ -29,10 +29,10 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
 
 		if (!path) return await next();
 
-		if (Deno.build.os !== "windows") {
+		if (Deno.build.os !== 'windows') {
 			path = `/${path}`;
 		}
-		
+
 		let file;
 
 		try {


### PR DESCRIPTION
## Description

Sometimes, we want to inject a plain object (such as a configuration object). `useValue` does that.

I remove TokenInjector to stay consistent.

---

## Issue Ticket Number

Fixes #(issue_number)

---

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [x] This change requires a documentation update

---

# Checklist:

- [x] I have run `deno lint` AND `deno fmt` AND `deno task test` and got no
      errors.
- [x] I have followed the contributing guidelines of this project as mentioned
      in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open
      [Pull Requests](https://github.com/Savory/Danet/pulls) for the same
      update/change?
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes needed to the documentation
