### PR TITLE
ci: add updater

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,20 @@
+name: update
+
+on:
+  schedule:
+    - cron: 0 12 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run updater
+        uses: boywithkeyboard/updater@v0


### PR DESCRIPTION
I think it would be a great addition to add updater to this repository.

Some dependencies seem totally out of date and there doesn't seem to be a convenient way to update them. This workflow will run at 12pm daily and check if there are any updates and if there are any, it'll open a pull request with the changes. Pretty straightforward.

Here's a link to the repository for more information:
<https://github.com/boywithkeyboard/updater>
