### PR TITLE
feat: add rate limiting service

### DIFF
--- a/spec/throttler.test.ts
+++ b/spec/throttler.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from '../src/deps_test.ts';
+import { DanetApplication } from '../src/app.ts';
+import { Controller, Get } from '../src/router/controller/decorator.ts';
+import { Module } from '../src/module/decorator.ts';
+import { Throttle } from '../src/throttler/decorator.ts';
+import { ThrottlerService, ThrottleGuard } from '../src/throttler/mod.ts';
+import { GLOBAL_GUARD } from '../src/guard/constants.ts';
+
+@Controller('throttle')
+class ThrottleController {
+  @Throttle(2, 1)
+  @Get('/')
+  simpleGet() {
+    return { ok: true };
+  }
+}
+
+@Module({
+  imports: [],
+  controllers: [ThrottleController],
+  injectables: [
+    ThrottlerService,
+    { useClass: ThrottleGuard, token: GLOBAL_GUARD },
+  ],
+})
+class ThrottleModule {}
+
+Deno.test('throttle guard limits requests', async () => {
+  const app = new DanetApplication();
+  await app.init(ThrottleModule);
+  const listenEvent = await app.listen(0);
+  const base = `http://localhost:${listenEvent.port}/throttle`;
+
+  const r1 = await fetch(base, { method: 'GET' });
+  assertEquals(r1.status, 200);
+  await r1?.body?.cancel();
+
+  const r2 = await fetch(base, { method: 'GET' });
+  assertEquals(r2.status, 200);
+  await r2?.body?.cancel();
+
+  const r3 = await fetch(base, { method: 'GET' });
+  assertEquals(r3.status, 429);
+  const json = await r3.json();
+  assertEquals(json, {
+    description: 'Too many requests',
+    message: '429 - Too many requests',
+    name: 'TooManyRequestsException',
+    status: 429,
+  });
+  await app.close();
+});

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -16,3 +16,4 @@ export * from './events/mod.ts';
 export * from './schedule/mod.ts';
 export * from './kv-queue/mod.ts';
 export * from './sse/mod.ts';
+export * from './throttler/mod.ts';

--- a/src/throttler/decorator.ts
+++ b/src/throttler/decorator.ts
@@ -1,0 +1,20 @@
+import { MetadataFunction, SetMetadata } from '../metadata/decorator.ts';
+
+export const throttleMetadataKey = 'throttle';
+
+/**
+ * Options for throttle metadata.
+ */
+export interface ThrottleOptions {
+  limit: number;
+  ttl?: number; // seconds
+}
+
+/**
+ * Apply throttle options to controller or handler.
+ * @param limit number of requests
+ * @param ttl seconds window
+ */
+export function Throttle(limit: number, ttl = 60): MetadataFunction {
+  return SetMetadata(throttleMetadataKey, { limit, ttl } as ThrottleOptions);
+}

--- a/src/throttler/guard.ts
+++ b/src/throttler/guard.ts
@@ -13,7 +13,7 @@ import { TooManyRequestsException } from '../exception/http/exceptions.ts';
 export class ThrottleGuard implements AuthGuard {
   constructor(private throttler: ThrottlerService) {}
 
-  async canActivate(context: ExecutionContext) {
+canActivate(context: ExecutionContext) {
     const handler = context.getHandler();
     const controller = context.getClass();
 

--- a/src/throttler/guard.ts
+++ b/src/throttler/guard.ts
@@ -32,7 +32,7 @@ canActivate(context: ExecutionContext) {
     }
 
     // default key: X-Forwarded-For header, fallbacks to remote address or global
-    const ip = context.req.header('x-forwarded-for') || context.req.header('x-real-ip') || context.req.connection?.remoteAddress || 'global';
+    const ip = context.req.header('x-forwarded-for') || context.req.header('x-real-ip') || 'global';
     const key = `${ip}:${context.getHandler().name}`;
 
     const count = this.throttler.consume(key, options.ttl || 60);

--- a/src/throttler/guard.ts
+++ b/src/throttler/guard.ts
@@ -32,8 +32,8 @@ canActivate(context: ExecutionContext) {
     }
 
     // default key: X-Forwarded-For header, fallbacks to remote address or global
-    const ip = context.req.header.get('x-forwarded-for') || context.req.header.get('x-real-ip') || 'global';
-    const key = `${context.get('_id') || ''}:${ip}:${context.getHandler().name}`;
+    const ip = context.req.header('x-forwarded-for') || context.req.header('x-real-ip') || context.req.connection?.remoteAddress || 'global';
+    const key = `${ip}:${context.getHandler().name}`;
 
     const count = this.throttler.consume(key, options.ttl || 60);
     if (count > options.limit) {

--- a/src/throttler/guard.ts
+++ b/src/throttler/guard.ts
@@ -1,0 +1,44 @@
+import { AuthGuard } from '../guard/interface.ts';
+import { ExecutionContext } from '../router/router.ts';
+import { MetadataHelper } from '../metadata/helper.ts';
+import { throttleMetadataKey, ThrottleOptions } from './decorator.ts';
+import { ThrottlerService } from './service.ts';
+import { Injectable } from '../injector/injectable/decorator.ts';
+import { TooManyRequestsException } from '../exception/http/exceptions.ts';
+
+/**
+ * A guard that checks throttle metadata (method/controller) and enforces limits.
+ */
+@Injectable()
+export class ThrottleGuard implements AuthGuard {
+  constructor(private throttler: ThrottlerService) {}
+
+  async canActivate(context: ExecutionContext) {
+    const handler = context.getHandler();
+    const controller = context.getClass();
+
+    const methodOptions = MetadataHelper.getMetadata<ThrottleOptions>(
+      throttleMetadataKey,
+      handler,
+    );
+    const controllerOptions = MetadataHelper.getMetadata<ThrottleOptions>(
+      throttleMetadataKey,
+      controller,
+    );
+    const options = methodOptions || controllerOptions;
+    if (!options) {
+      // nothing to do
+      return true;
+    }
+
+    // default key: X-Forwarded-For header, fallbacks to remote address or global
+    const ip = context.req.headers.get('x-forwarded-for') || context.req.headers.get('x-real-ip') || 'global';
+    const key = `${context.get('_id') || ''}:${ip}:${context.getHandler().name}`;
+
+    const count = this.throttler.consume(key, options.ttl || 60);
+    if (count > options.limit) {
+      throw new TooManyRequestsException();
+    }
+    return true;
+  }
+}

--- a/src/throttler/guard.ts
+++ b/src/throttler/guard.ts
@@ -32,7 +32,7 @@ canActivate(context: ExecutionContext) {
     }
 
     // default key: X-Forwarded-For header, fallbacks to remote address or global
-    const ip = context.req.headers.get('x-forwarded-for') || context.req.headers.get('x-real-ip') || 'global';
+    const ip = context.req.header.get('x-forwarded-for') || context.req.header.get('x-real-ip') || 'global';
     const key = `${context.get('_id') || ''}:${ip}:${context.getHandler().name}`;
 
     const count = this.throttler.consume(key, options.ttl || 60);

--- a/src/throttler/mod.ts
+++ b/src/throttler/mod.ts
@@ -1,0 +1,3 @@
+export * from './decorator.ts';
+export * from './guard.ts';
+export * from './service.ts';

--- a/src/throttler/service.ts
+++ b/src/throttler/service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '../injector/injectable/decorator.ts';
+
+/**
+ * Very small in-memory throttler.
+ * Stores timestamps per key and prunes them on each hit.
+ */
+@Injectable()
+export class ThrottlerService {
+  private store = new Map<string, number[]>();
+
+  /**
+   * Returns current count after adding this request timestamp.
+   * Prunes entries older than ttl seconds.
+   */
+  consume(key: string, ttl: number): number {
+    const now = Date.now();
+    const windowStart = now - ttl * 1000;
+    const list = this.store.get(key) || [];
+    const pruned = list.filter((ts) => ts > windowStart);
+    pruned.push(now);
+    this.store.set(key, pruned);
+    return pruned.length;
+  }
+
+  /**
+   * For tests and diagnostics: reset store
+   */
+  reset() {
+    this.store.clear();
+  }
+}


### PR DESCRIPTION
## Description

Add new rate limiting guard/service/decorators

---

## Issue Ticket Number

Fixes #123

---

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [x] This change requires a documentation update

---

# Checklist:

- [ ] I have run `deno lint` AND `deno fmt` AND `deno task test` and got no
      errors.
- [ ] I have followed the contributing guidelines of this project as mentioned
      in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have checked to ensure there aren't other open
      [Pull Requests](https://github.com/Savory/Danet/pulls) for the same
      update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes needed to the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced configurable per-endpoint rate limiting with per-client enforcement and time-window settings.
  * Exceeding limits returns HTTP 429 with structured "Too Many Requests" error details.

* **Tests**
  * Added end-to-end tests that verify allowed requests and 429 responses when limits are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->