### PR TITLE
test(response): cover blob body and header setting

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@danet/core",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"license": "MIT",
 	"exports": {
 		".": "./mod.ts",

--- a/spec/response-decorator.test.ts
+++ b/spec/response-decorator.test.ts
@@ -2,12 +2,40 @@ import { All, Controller, Delete, Get, HttpCode, Patch, Post, Put } from '../src
 import { Module } from '../src/module/decorator.ts';
 import { DanetApplication } from '../src/app.ts';
 import { assertEquals } from '../src/deps_test.ts';
+import { Context, Res } from '../src/router/controller/params/decorators.ts';
+import type { ExecutionContext } from '../src/mod.ts';
 
 @Controller('nice-controller')
 class SimpleController {
     @Get('/')
     simpleGet() {
         return new Response('OK GET', { status: 201 });
+    }
+
+    @Get('blob')
+    blobWithHeaders() {
+        const blob = new Blob(['hello blob'], { type: 'text/plain' });
+        return new Response(blob, {
+            status: 200,
+            headers: {
+                'Content-Type': 'text/plain',
+                'Content-Disposition': 'attachment; filename="hello.txt"',
+                'X-Custom-Header': 'from-response',
+            },
+        });
+    }
+
+    @Get('with-res')
+    setHeaderWithRes(@Res() res: Response) {
+        res.headers.set('X-Custom-Header', 'from-res');
+        return { ok: true };
+    }
+
+    @Get('with-context')
+    setBodyWithContext(@Context() ctx: ExecutionContext) {
+        const data = new TextEncoder().encode('hello context');
+        ctx.header('X-Custom-Header', 'from-context');
+        return ctx.body(data);
     }
 }
 
@@ -30,5 +58,59 @@ Deno.test('HttpCode', async () => {
     const text = await res.text();
     assertEquals(text, `OK GET`);
     assertEquals(res.status, 201);
+    await app.close();
+});
+
+Deno.test('returning a Response with a Blob body sets body and headers', async () => {
+    const app = new DanetApplication();
+    await app.init(MyModule);
+    const listenEvent = await app.listen(0);
+
+    const res = await fetch(
+        `http://localhost:${listenEvent.port}/nice-controller/blob`,
+        {
+            method: 'GET',
+        },
+    );
+    assertEquals(await res.text(), 'hello blob');
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get('Content-Type'), 'text/plain');
+    assertEquals(
+        res.headers.get('Content-Disposition'),
+        'attachment; filename="hello.txt"',
+    );
+    assertEquals(res.headers.get('X-Custom-Header'), 'from-response');
+    await app.close();
+});
+
+Deno.test('@Res lets you set headers while returning a value', async () => {
+    const app = new DanetApplication();
+    await app.init(MyModule);
+    const listenEvent = await app.listen(0);
+
+    const res = await fetch(
+        `http://localhost:${listenEvent.port}/nice-controller/with-res`,
+        {
+            method: 'GET',
+        },
+    );
+    assertEquals(await res.json(), { ok: true });
+    assertEquals(res.headers.get('X-Custom-Header'), 'from-res');
+    await app.close();
+});
+
+Deno.test('@Context lets you set the body and headers', async () => {
+    const app = new DanetApplication();
+    await app.init(MyModule);
+    const listenEvent = await app.listen(0);
+
+    const res = await fetch(
+        `http://localhost:${listenEvent.port}/nice-controller/with-context`,
+        {
+            method: 'GET',
+        },
+    );
+    assertEquals(await res.text(), 'hello context');
+    assertEquals(res.headers.get('X-Custom-Header'), 'from-context');
     await app.close();
 });

--- a/spec/response-decorator.test.ts
+++ b/spec/response-decorator.test.ts
@@ -33,9 +33,8 @@ class SimpleController {
 
     @Get('with-context')
     setBodyWithContext(@Context() ctx: ExecutionContext) {
-        const data = new TextEncoder().encode('hello context');
         ctx.header('X-Custom-Header', 'from-context');
-        return ctx.body(data);
+        return ctx.body('hello context');
     }
 }
 

--- a/src/router/controller/params/decorators.ts
+++ b/src/router/controller/params/decorators.ts
@@ -87,7 +87,7 @@ export function createParamDecorator(
 /**
  * Get current request
  */
-export const Req: DecoratorFunction = createParamDecorator(
+export const Req: () => DecoratorFunction = createParamDecorator(
 	(context: ExecutionContext) => {
 		return context.req;
 	},
@@ -96,7 +96,7 @@ export const Req: DecoratorFunction = createParamDecorator(
 /**
  * Get current response
  */
-export const Res: DecoratorFunction = createParamDecorator(
+export const Res: () => DecoratorFunction = createParamDecorator(
 	(context: ExecutionContext) => {
 		return context.res;
 	},


### PR DESCRIPTION
Addresses [discussion #121](https://github.com/Savory/Danet/discussions/121): *"How can I set the headers of the response and the body as a blob?"*

Adds tests to `spec/response-decorator.test.ts` asserting the three supported ways to do this:

1. **Return a `Response`** with a `Blob` body + custom headers (`Content-Type`, `Content-Disposition`, custom header) — sent as-is.
2. **`@Res()`** to mutate response headers while returning a plain value (Danet merges `context.res.headers`).
3. **`@Context()`** to set the body and headers via Hono helpers (`c.header()`, `c.body()`).

The matching user-facing documentation lives in a companion PR on `Savory/docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnF4fzmM7CwBfq7zXBnQsF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new integration coverage for three response-handling scenarios using parameter decorators.
  * Verified binary (Blob) response bodies and headers like `Content-Type` and `Content-Disposition`.
  * Verified custom headers when using provided response objects and when setting headers via context.
  * Confirmed existing HTTP status code coverage remains unchanged.
* **Refactor**
  * Improved type annotations for request/response decorator helpers (`Req`/`Res`) for better type safety.
* **Chores**
  * Bumped the project version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->